### PR TITLE
Fixing a problem in 'TestForEachRight' that appears because it incorrectly relies on the underlying implementation of Map in Golang

### DIFF
--- a/scan_test.go
+++ b/scan_test.go
@@ -49,11 +49,12 @@ func TestForEachRight(t *testing.T) {
 
 	ForEachRight(mapping, func(k int, v string) {
 		is.Equal(v, mapping[k])
-
 		mapKeys = append(mapKeys, k)
 	})
 
-	is.Equal(mapKeys, []int{2, 1})
+	is.Equal(len(mapKeys), 2)
+	is.Contains(mapKeys, 1)
+	is.Contains(mapKeys, 2)
 }
 
 func TestHead(t *testing.T) {


### PR DESCRIPTION
This is fixing a problem in 'TestForEachRight' that appears because it incorrectly relies on the underlying implementation of Map in Golang

The ordering is not guaranteed, but rather the slice output format is randomized strictly to disallow reliying on it. This happens at least for all Goversions >=1.7.

Check that numbers are in the output without asserting the order.

This is also the reason why unit tests on master fail every now and then, and made worse by running tests on 1.8 and 1.9!

Provoke the problem by running the test quite repeatedly until it fails:

    (set -e && for i in {1..100}; do go test; done)