### PR TITLE
Remove rand.Seed from RandomInt

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"math/rand"
 	"reflect"
-	"time"
 )
 
 var numericZeros = []interface{}{

--- a/helpers.go
+++ b/helpers.go
@@ -244,8 +244,6 @@ func ZeroOf(in interface{}) interface{} {
 
 // RandomInt generates a random int, based on a min and max values
 func RandomInt(min, max int) int {
-	rand.Seed(time.Now().UTC().UnixNano())
-
 	return min + rand.Intn(max-min)
 }
 


### PR DESCRIPTION
I believe it's better to avoid seeding the global rand source here.