### PR TITLE
Support xxxInt32 operations

### DIFF
--- a/typesafe.go
+++ b/typesafe.go
@@ -7,6 +7,11 @@ func InInts(s []int, v int) bool {
 	return ContainsInt(s, v)
 }
 
+// InInt32s is an alias of ContainsInt32, returns true if an int32 is present in a iteratee.
+func InInt32s(s []int32, v int32) bool {
+	return ContainsInt32(s, v)
+}
+
 // InInt64s is an alias of ContainsInt64, returns true if an int64 is present in a iteratee.
 func InInt64s(s []int64, v int64) bool {
 	return ContainsInt64(s, v)
@@ -58,6 +63,20 @@ func FindFloat32(s []float32, cb func(s float32) bool) (float32, bool) {
 // FindInt iterates over a collection of int, returning the first
 // int element predicate returns truthy for.
 func FindInt(s []int, cb func(s int) bool) (int, bool) {
+	for _, i := range s {
+		result := cb(i)
+
+		if result {
+			return i, true
+		}
+	}
+
+	return 0, false
+}
+
+// FindInt32 iterates over a collection of int32, returning the first
+// int32 element predicate returns truthy for.
+func FindInt32(s []int32, cb func(s int32) bool) (int32, bool) {
 	for _, i := range s {
 		result := cb(i)
 
@@ -145,6 +164,22 @@ func FilterInt(s []int, cb func(s int) bool) []int {
 	return results
 }
 
+// FilterInt32 iterates over a collection of int32, returning an array of
+// all int32 elements predicate returns truthy for.
+func FilterInt32(s []int32, cb func(s int32) bool) []int32 {
+	results := []int32{}
+
+	for _, i := range s {
+		result := cb(i)
+
+		if result {
+			results = append(results, i)
+		}
+	}
+
+	return results
+}
+
 // FilterInt64 iterates over a collection of int64, returning an array of
 // all int64 elements predicate returns truthy for.
 func FilterInt64(s []int64, cb func(s int64) bool) []int64 {
@@ -179,6 +214,16 @@ func FilterString(s []string, cb func(s string) bool) []string {
 
 // ContainsInt returns true if an int is present in a iteratee.
 func ContainsInt(s []int, v int) bool {
+	for _, vv := range s {
+		if vv == v {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsInt32 returns true if an int32 is present in a iteratee.
+func ContainsInt32(s []int32, v int32) bool {
 	for _, vv := range s {
 		if vv == v {
 			return true
@@ -227,6 +272,14 @@ func ContainsFloat64(s []float64, v float64) bool {
 	return false
 }
 
+// SumInt32 sums a int32 iteratee and returns the sum of all elements
+func SumInt32(s []int32) (sum int32) {
+	for _, v := range s {
+		sum += v
+	}
+	return
+}
+
 // SumInt64 sums a int64 iteratee and returns the sum of all elements
 func SumInt64(s []int64) (sum int64) {
 	for _, v := range s {
@@ -269,6 +322,14 @@ func ReverseStrings(s []string) []string {
 
 // ReverseInt reverses an array of int
 func ReverseInt(s []int) []int {
+	for i, j := 0, len(s)-1; i < len(s)/2; i, j = i+1, j-1 {
+		s[i], s[j] = s[j], s[i]
+	}
+	return s
+}
+
+// ReverseInt32 reverses an array of int32
+func ReverseInt32(s []int32) []int32 {
 	for i, j := 0, len(s)-1; i < len(s)/2; i, j = i+1, j-1 {
 		s[i], s[j] = s[j], s[i]
 	}
@@ -323,6 +384,12 @@ func IndexOfInt(a []int, x int) int {
 	return indexOf(len(a), func(i int) bool { return a[i] == x })
 }
 
+// IndexOfInt32 gets the index at which the first occurrence of an int32 value is found in array or return -1
+// if the value cannot be found
+func IndexOfInt32(a []int32, x int32) int {
+	return indexOf(len(a), func(i int) bool { return a[i] == x })
+}
+
 // IndexOfInt64 gets the index at which the first occurrence of an int64 value is found in array or return -1
 // if the value cannot be found
 func IndexOfInt64(a []int64, x int64) int {
@@ -356,6 +423,12 @@ func LastIndexOfInt(a []int, x int) int {
 	return lastIndexOf(len(a), func(i int) bool { return a[i] == x })
 }
 
+// LastIndexOfInt32 gets the index at which the first occurrence of an int32 value is found in array or return -1
+// if the value cannot be found
+func LastIndexOfInt32(a []int32, x int32) int {
+	return lastIndexOf(len(a), func(i int) bool { return a[i] == x })
+}
+
 // LastIndexOfInt64 gets the index at which the first occurrence of an int64 value is found in array or return -1
 // if the value cannot be found
 func LastIndexOfInt64(a []int64, x int64) int {
@@ -378,6 +451,28 @@ func LastIndexOfFloat32(a []float32, x float32) int {
 // if the value cannot be found
 func LastIndexOfString(a []string, x string) int {
 	return lastIndexOf(len(a), func(i int) bool { return a[i] == x })
+}
+
+// UniqInt32 creates an array of int32 with unique values.
+func UniqInt32(a []int32) []int32 {
+	length := len(a)
+
+	seen := make(map[int32]struct{}, length)
+	j := 0
+
+	for i := 0; i < length; i++ {
+		v := a[i]
+
+		if _, ok := seen[v]; ok {
+			continue
+		}
+
+		seen[v] = struct{}{}
+		a[j] = v
+		j++
+	}
+
+	return a[0:j]
 }
 
 // UniqInt64 creates an array of int64 with unique values.
@@ -492,6 +587,16 @@ func UniqFloat32(a []float32) []float32 {
 
 // ShuffleInt creates an array of int shuffled values using Fisher–Yates algorithm
 func ShuffleInt(a []int) []int {
+	for i := range a {
+		j := rand.Intn(i + 1)
+		a[i], a[j] = a[j], a[i]
+	}
+
+	return a
+}
+
+// ShuffleInt32 creates an array of int32 shuffled values using Fisher–Yates algorithm
+func ShuffleInt32(a []int32) []int32 {
 	for i := range a {
 		j := rand.Intn(i + 1)
 		a[i], a[j] = a[j], a[i]

--- a/typesafe_test.go
+++ b/typesafe_test.go
@@ -12,6 +12,9 @@ func TestContainsInt(t *testing.T) {
 	is.True(ContainsInt([]int{1, 2, 3, 4}, 4))
 	is.False(ContainsInt([]int{1, 2, 3, 4}, 5))
 
+	is.True(ContainsInt32([]int32{1, 2, 3, 4}, 4))
+	is.False(ContainsInt32([]int32{1, 2, 3, 4}, 5))
+
 	is.True(ContainsInt64([]int64{1, 2, 3, 4}, 4))
 	is.False(ContainsInt64([]int64{1, 2, 3, 4}, 5))
 }
@@ -41,6 +44,16 @@ func TestFilterInt(t *testing.T) {
 	})
 
 	is.Equal(r, []int{2, 4})
+}
+
+func TestFilterInt32(t *testing.T) {
+	is := assert.New(t)
+
+	r := FilterInt32([]int32{1, 2, 3, 4}, func(x int32) bool {
+		return x%2 == 0
+	})
+
+	is.Equal(r, []int32{2, 4})
 }
 
 func TestFilterInt64(t *testing.T) {


### PR DESCRIPTION
There are int, **int32**, int64 in Go.
Why not support int32? 😄 