### PR TITLE
Support Contains() for arrays too

### DIFF
--- a/presence.go
+++ b/presence.go
@@ -146,7 +146,7 @@ func Contains(in interface{}, elem interface{}) bool {
 				return true
 			}
 		}
-	case reflect.Slice:
+	case reflect.Slice, reflect.Array:
 		for i := 0; i < inValue.Len(); i++ {
 			if equal(inValue.Index(i).Interface(), elem) {
 				return true

--- a/presence_test.go
+++ b/presence_test.go
@@ -35,6 +35,7 @@ func TestContains(t *testing.T) {
 	is := assert.New(t)
 
 	is.True(Contains([]string{"foo", "bar"}, "bar"))
+	is.True(Contains([...]string{"foo", "bar"}, "bar"))
 
 	is.True(Contains(results, f))
 	is.False(Contains(results, nil))


### PR DESCRIPTION
As of now, `Contains()` will return `false` if called on an array (i.e. a fixed length slice). This PR fixes the issue.