### PR TITLE
Contains will panic on unsupported types instead of returning false

### DIFF
--- a/presence.go
+++ b/presence.go
@@ -1,6 +1,7 @@
 package funk
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 )
@@ -152,6 +153,8 @@ func Contains(in interface{}, elem interface{}) bool {
 				return true
 			}
 		}
+	default:
+		panic(fmt.Sprintf("Type %s is not supported by Contains, supported types are String, Map, Slice, Array", inType.String()))
 	}
 
 	return false

--- a/presence_test.go
+++ b/presence_test.go
@@ -36,6 +36,7 @@ func TestContains(t *testing.T) {
 
 	is.True(Contains([]string{"foo", "bar"}, "bar"))
 	is.True(Contains([...]string{"foo", "bar"}, "bar"))
+	is.Panics(func() { Contains(1, 2) })
 
 	is.True(Contains(results, f))
 	is.False(Contains(results, nil))


### PR DESCRIPTION
Hi,

I changed function `Contains` to throw a panic when the type is not supported by the function. 

I had a case where in my project when using `Contains` with an unsupported type was not signaled and it took me some time to find it out :neckbeard: 

For the test case I just check if an unsupported type throws a panic.