### PR TITLE
fix the bug reflect on zero Value

### DIFF
--- a/retrieve.go
+++ b/retrieve.go
@@ -21,7 +21,11 @@ func get(value reflect.Value, path string) reflect.Value {
 		var resultSlice reflect.Value
 
 		length := value.Len()
-
+		
+		if length == 0 {
+			return resultSlice
+		}
+		
 		for i := 0; i < length; i++ {
 			item := value.Index(i)
 


### PR DESCRIPTION
fix the bug ：reflect: call of reflect.Value.Type on zero Value

if the slice is nil， or len==0， will be panic.
the case:

```
type Foo struct{
	Bar[]int
}

func TestGoFunk(t *testing.T) {
	foo := []Foo{}
	bars := funk.Get(foo, "Bar") //panic !!
	fmt.Print(bars)
}
```