### PR TITLE
fix bug in lastIndexOf

### DIFF
--- a/typesafe.go
+++ b/typesafe.go
@@ -411,7 +411,7 @@ func IndexOfString(a []string, x string) int {
 }
 
 func lastIndexOf(n int, f func(int) bool) int {
-	for i := n - 1; i > 0; i-- {
+	for i := n - 1; i >= 0; i-- {
 		if f(i) {
 			return i
 		}


### PR DESCRIPTION
Thanks for the library.

When the expected return value of LastIndexOf... should be 0, -1 is returned. This PR fixes an iteration in lastIndexOf, thereby fixing the bug.