### PR TITLE
Add support for funk.Difference

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,6 +135,21 @@ see also, typesafe implementations: ContainsInt_, ContainsInt64_, ContainsFloat3
 .. _ContainsInt64: https://godoc.org/github.com/thoas/go-funk#ContainsInt64
 .. _ContainsString: https://godoc.org/github.com/thoas/go-funk#ContainsString
 
+funk.Intersect
+..............
+
+Returns the intersection between two collections.
+
+```
+inter := funk.Intersect([]int{1, 2, 3, 4}, []int{2, 4, 6})  // []int{2, 4}
+inter := funk.Intersect([]string{"foo", "bar", "hello", "bar"}, []string{"foo", "bar"})  // []string{"foo", "bar"}
+```
+
+see also, typesafe implementations: IntersectString
+
+.. IntersectString: https://godoc.org/github.com/thoas/go-funk#IntersectString
+
+
 funk.IndexOf
 ............
 

--- a/README.rst
+++ b/README.rst
@@ -150,6 +150,21 @@ see also, typesafe implementations: IntersectString
 .. IntersectString: https://godoc.org/github.com/thoas/go-funk#IntersectString
 
 
+funk.Difference
+..............
+
+Returns the difference between two collections.
+
+```
+left, right := funk.Difference([]int{1, 2, 3, 4}, []int{2, 4, 6})  // []int{1, 3}, []int{6}
+left, right := funk.Difference([]string{"foo", "bar", "hello", "bar"}, []string{"foo", "bar"})  // []string{"hello"}, []string{}
+```
+
+see also, typesafe implementations: DifferenceString
+
+.. DifferenceString: https://godoc.org/github.com/thoas/go-funk#DifferenceString
+
+
 funk.IndexOf
 ............
 

--- a/intersection.go
+++ b/intersection.go
@@ -66,3 +66,64 @@ func IntersectString(x []string, y []string) []string {
 
 	return set
 }
+
+// Difference returns the difference between two collections.
+func Difference(x interface{}, y interface{}) (interface{}, interface{}) {
+	if !IsCollection(x) {
+		panic("First parameter must be a collection")
+	}
+	if !IsCollection(y) {
+		panic("Second parameter must be a collection")
+	}
+
+	xValue := reflect.ValueOf(x)
+	xType := xValue.Type()
+
+	yValue := reflect.ValueOf(y)
+	yType := yValue.Type()
+
+	if NotEqual(xType, yType) {
+		panic("Parameters must have the same type")
+	}
+
+	leftType := reflect.SliceOf(xType.Elem())
+	leftSlice := reflect.MakeSlice(leftType, 0, 0)
+	rightType := reflect.SliceOf(yType.Elem())
+	rightSlice := reflect.MakeSlice(rightType, 0, 0)
+
+	for i := 0; i < xValue.Len(); i++ {
+		v := xValue.Index(i).Interface()
+		if Contains(y, v) == false {
+			leftSlice = reflect.Append(leftSlice, xValue.Index(i))
+		}
+	}
+
+	for i := 0; i < yValue.Len(); i++ {
+		v := yValue.Index(i).Interface()
+		if Contains(x, v) == false {
+			rightSlice = reflect.Append(rightSlice, yValue.Index(i))
+		}
+	}
+
+	return leftSlice.Interface(), rightSlice.Interface()
+}
+
+// DifferenceString returns the difference between two collections of strings.
+func DifferenceString(x []string, y []string) ([]string, []string) {
+	leftSlice := []string{}
+	rightSlice := []string{}
+
+	for _, v := range x {
+		if Contains(y, v) == false {
+			leftSlice = append(leftSlice, v)
+		}
+	}
+
+	for _, v := range y {
+		if Contains(x, v) == false {
+			rightSlice = append(rightSlice, v)
+		}
+	}
+
+	return leftSlice, rightSlice
+}

--- a/intersection.go
+++ b/intersection.go
@@ -114,13 +114,13 @@ func DifferenceString(x []string, y []string) ([]string, []string) {
 	rightSlice := []string{}
 
 	for _, v := range x {
-		if Contains(y, v) == false {
+		if ContainsString(y, v) == false {
 			leftSlice = append(leftSlice, v)
 		}
 	}
 
 	for _, v := range y {
-		if Contains(x, v) == false {
+		if ContainsString(x, v) == false {
 			rightSlice = append(rightSlice, v)
 		}
 	}

--- a/intersection_test.go
+++ b/intersection_test.go
@@ -24,3 +24,25 @@ func TestIntersectString(t *testing.T) {
 	is.Equal(r, []string{"foo", "bar"})
 
 }
+
+func TestDifference(t *testing.T) {
+	is := assert.New(t)
+
+	r1, r2 := Difference([]int{1, 2, 3, 4}, []int{2, 4, 6})
+	is.Equal(r1, []int{1, 3})
+	is.Equal(r2, []int{6})
+
+	r1, r2 = Difference([]string{"foo", "bar", "hello", "bar"}, []string{"foo", "bar"})
+	is.Equal(r1, []string{"hello"})
+	is.Equal(r2, []string{})
+
+}
+
+func TestDifferenceString(t *testing.T) {
+	is := assert.New(t)
+
+	r1, r2 := DifferenceString([]string{"foo", "bar", "hello", "bar"}, []string{"foo", "bar"})
+	is.Equal(r1, []string{"hello"})
+	is.Equal(r2, []string{})
+
+}


### PR DESCRIPTION
Returns the difference between two collections.

```golang
left, right := funk.Difference([]int{1, 2, 3, 4}, []int{2, 4, 6})  // []int{1, 3}, []int{6}
left, right := funk.Difference([]string{"foo", "bar", "hello", "bar"}, []string{"foo", "bar"})  // []string{"hello"}, []string{}
```

Solving #13 