### PR TITLE
Subtract: Preserve order and duplication

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -524,6 +524,21 @@ see also, typesafe implementations: ShuffleInt_, ShuffleInt64_, ShuffleFloat32_,
 .. _ShuffleInt64: https://godoc.org/github.com/thoas/go-funk#ShuffleInt64
 .. _ShuffleString: https://godoc.org/github.com/thoas/go-funk#ShuffleString
 
+funk.Subtract
+............
+
+Returns the subtraction between two collections. It preserve order.
+
+.. code-block:: go
+
+    funk.Subtract([]int{0, 1, 2, 3, 4}, []int{0, 4}) // []int{1, 2, 3}
+    funk.Subtract([]int{0, 3, 2, 3, 4}, []int{0, 4}) // []int{3, 2, 3}
+
+
+see also, typesafe implementations: SubtractString_
+
+.. SubtractString: https://godoc.org/github.com/thoas/go-funk#SubtractString
+
 funk.Sum
 ........
 

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -17,6 +17,18 @@ func sliceGenerator(size uint, r *rand.Rand) (out []int64) {
 	return
 }
 
+func BenchmarkSubtract(b *testing.B) {
+	r := rand.New(rand.NewSource(seed))
+	testData := sliceGenerator(sliceSize, r)
+	what := sliceGenerator(sliceSize, r)
+
+	b.Run("Subtract", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			Subtract(testData, what)
+		}
+	})
+}
+
 func BenchmarkContains(b *testing.B) {
 	r := rand.New(rand.NewSource(seed))
 	testData := sliceGenerator(sliceSize, r)

--- a/subtraction.go
+++ b/subtraction.go
@@ -41,9 +41,12 @@ func Subtract(x interface{}, y interface{}) interface{} {
 		}
 	}
 
-	for k, _ := range hash {
-		kValue := reflect.ValueOf(k)
-		zSlice = reflect.Append(zSlice, kValue)
+	for i := 0; i < xValue.Len(); i++ {
+		v := xValue.Index(i).Interface()
+		_, ok := hash[v]
+		if ok {
+			zSlice = reflect.Append(zSlice, xValue.Index(i))
+		}
 	}
 
 	return zSlice.Interface()
@@ -55,7 +58,7 @@ func SubtractString(x []string, y []string) []string {
 		return []string{}
 	}
 
-	set := []string{}
+	slice := []string{}
 	hash := map[string]struct{}{}
 
 	for _, v := range x {
@@ -69,9 +72,12 @@ func SubtractString(x []string, y []string) []string {
 		}
 	}
 
-	for k, _ := range hash {
-		set = append(set, k)
+	for _, v := range x {
+		_, ok := hash[v]
+		if ok {
+			slice = append(slice, v)
+		}
 	}
 
-	return set
+	return slice
 }

--- a/subtraction_test.go
+++ b/subtraction_test.go
@@ -14,6 +14,9 @@ func TestSubtract(t *testing.T) {
 
 	r = Subtract([]string{"foo", "bar", "hello", "bar", "hi"}, []string{"foo", "bar"})
 	is.Equal([]string{"hello", "hi"}, r)
+
+	r = Subtract([]string{"hello", "foo", "bar", "hello", "bar", "hi"}, []string{"foo", "bar"})
+	is.Equal([]string{"hello", "hello", "hi"}, r)
 }
 
 func TestSubtractString(t *testing.T) {
@@ -21,4 +24,7 @@ func TestSubtractString(t *testing.T) {
 
 	r := SubtractString([]string{"foo", "bar", "hello", "bar"}, []string{"foo", "bar"})
 	is.Equal([]string{"hello"}, r)
+
+	r = SubtractString([]string{"foo", "bar", "hello", "bar", "world", "world"}, []string{"foo", "bar"})
+	is.Equal([]string{"hello", "world", "world"}, r)
 }


### PR DESCRIPTION
Subtract tests were sometimes crashing, because of random output.

Subtract function is now 5-10% slower.
