### PR TITLE
Implement Join methods for "generic" and some primitives

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -103,3 +103,22 @@ func BenchmarkDrop(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkJoin(b *testing.B) {
+	r := rand.New(rand.NewSource(seed))
+	fullArr := sliceGenerator(sliceSize, r)
+	leftArr := fullArr[:sliceSize/3*2]
+	rightArr := fullArr[sliceSize/3*1:]
+
+	b.Run("InnerJoinInt64", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			JoinInt64(leftArr, rightArr, InnerJoinInt64)
+		}
+	})
+
+	b.Run("InnerJoin", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			Join(leftArr, rightArr, InnerJoin)
+		}
+	})
+}

--- a/builder.go
+++ b/builder.go
@@ -14,6 +14,7 @@ type Builder interface {
 	FlattenDeep() Builder
 	Initial() Builder
 	Intersect(y interface{}) Builder
+	Join(rarr interface{}, fnc JoinFnc) Builder
 	Map(mapFunc interface{}) Builder
 	Reverse() Builder
 	Shuffle() Builder

--- a/chain_builder.go
+++ b/chain_builder.go
@@ -30,6 +30,9 @@ func (b *chainBuilder) Initial() Builder {
 func (b *chainBuilder) Intersect(y interface{}) Builder {
 	return &chainBuilder{Intersect(b.collection, y)}
 }
+func (b *chainBuilder) Join(rarr interface{}, fnc JoinFnc) Builder {
+	return &chainBuilder{Join(b.collection, rarr, fnc)}
+}
 func (b *chainBuilder) Map(mapFunc interface{}) Builder {
 	return &chainBuilder{Map(b.collection, mapFunc)}
 }

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/intersection.go
+++ b/intersection.go
@@ -5,6 +5,10 @@ import (
 )
 
 // Intersect returns the intersection between two collections.
+//
+// Deprecated: use Join(x, y, InnerJoin) instead of Intersect, InnerJoin
+// implements deduplication mechanism, so verify your code behaviour
+// before using it
 func Intersect(x interface{}, y interface{}) interface{} {
 	if !IsCollection(x) {
 		panic("First parameter must be a collection")

--- a/intersection_test.go
+++ b/intersection_test.go
@@ -15,6 +15,9 @@ func TestIntersect(t *testing.T) {
 	r = Intersect([]string{"foo", "bar", "hello", "bar"}, []string{"foo", "bar"})
 	is.Equal(r, []string{"foo", "bar"})
 
+	r = Intersect([]string{"foo", "bar"}, []string{"foo", "bar", "hello", "bar"})
+	is.Equal(r, []string{"foo", "bar", "bar"})
+
 }
 
 func TestIntersectString(t *testing.T) {

--- a/join.go
+++ b/join.go
@@ -1,0 +1,86 @@
+package funk
+
+import (
+	"reflect"
+)
+
+type JoinFnc func(lx, rx reflect.Value) reflect.Value
+
+// Join combines two collections using the given join method.
+func Join(larr, rarr interface{}, fnc JoinFnc) interface{} {
+	if !IsCollection(larr) {
+		panic("First parameter must be a collection")
+	}
+	if !IsCollection(rarr) {
+		panic("Second parameter must be a collection")
+	}
+
+	lvalue := reflect.ValueOf(larr)
+	rvalue := reflect.ValueOf(rarr)
+	if NotEqual(lvalue.Type(), rvalue.Type()) {
+		panic("Parameters must have the same type")
+	}
+
+	return fnc(lvalue, rvalue).Interface()
+}
+
+// InnerJoin finds and returns matching data from two collections.
+func InnerJoin(lx, rx reflect.Value) reflect.Value {
+	result := reflect.MakeSlice(reflect.SliceOf(lx.Type().Elem()), 0, lx.Len()+rx.Len())
+	rhash := hashSlice(rx)
+	lhash := make(map[interface{}]struct{}, lx.Len())
+
+	for i := 0; i < lx.Len(); i++ {
+		v := lx.Index(i)
+		_, ok := rhash[v.Interface()]
+		_, alreadyExists := lhash[v.Interface()]
+		if ok && !alreadyExists {
+			lhash[v.Interface()] = struct{}{}
+			result = reflect.Append(result, v)
+		}
+	}
+	return result
+}
+
+// OuterJoin finds and returns dissimilar data from two collections.
+func OuterJoin(lx, rx reflect.Value) reflect.Value {
+	ljoin := LeftJoin(lx, rx)
+	rjoin := RightJoin(lx, rx)
+
+	result := reflect.MakeSlice(reflect.SliceOf(lx.Type().Elem()), ljoin.Len()+rjoin.Len(), ljoin.Len()+rjoin.Len())
+	for i := 0; i < ljoin.Len(); i++ {
+		result.Index(i).Set(ljoin.Index(i))
+	}
+	for i := 0; i < rjoin.Len(); i++ {
+		result.Index(ljoin.Len() + i).Set(rjoin.Index(i))
+	}
+
+	return result
+}
+
+// LeftJoin finds and returns dissimilar data from the first collection (left).
+func LeftJoin(lx, rx reflect.Value) reflect.Value {
+	result := reflect.MakeSlice(reflect.SliceOf(lx.Type().Elem()), 0, lx.Len())
+	rhash := hashSlice(rx)
+
+	for i := 0; i < lx.Len(); i++ {
+		v := lx.Index(i)
+		_, ok := rhash[v.Interface()]
+		if !ok {
+			result = reflect.Append(result, v)
+		}
+	}
+	return result
+}
+
+// LeftJoin finds and returns dissimilar data from the second collection (right).
+func RightJoin(lx, rx reflect.Value) reflect.Value { return LeftJoin(rx, lx) }
+
+func hashSlice(arr reflect.Value) map[interface{}]struct{} {
+	hash := map[interface{}]struct{}{}
+	for i := 0; i < arr.Len(); i++ {
+		v := arr.Index(i).Interface()
+		hash[v] = struct{}{}
+	}
+	return hash
+}

--- a/join_primitives.go
+++ b/join_primitives.go
@@ -1,0 +1,385 @@
+package funk
+
+type JoinIntFnc func(lx, rx []int) []int
+
+// JoinInt combines two int collections using the given join method.
+func JoinInt(larr, rarr []int, fnc JoinIntFnc) []int {
+	return fnc(larr, rarr)
+}
+
+// InnerJoinInt finds and returns matching data from two int collections.
+func InnerJoinInt(lx, rx []int) []int {
+	result := make([]int, 0, len(lx)+len(rx))
+	rhash := hashSliceInt(rx)
+	lhash := make(map[int]struct{}, len(lx))
+
+	for _, v := range lx {
+		_, ok := rhash[v]
+		_, alreadyExists := lhash[v]
+		if ok && !alreadyExists {
+			lhash[v] = struct{}{}
+			result = append(result, v)
+		}
+	}
+	return result
+}
+
+// OuterJoinInt finds and returns dissimilar data from two int collections.
+func OuterJoinInt(lx, rx []int) []int {
+	ljoin := LeftJoinInt(lx, rx)
+	rjoin := RightJoinInt(lx, rx)
+
+	result := make([]int, len(ljoin)+len(rjoin))
+	for i, v := range ljoin {
+		result[i] = v
+	}
+	for i, v := range rjoin {
+		result[len(ljoin)+i] = v
+	}
+	return result
+}
+
+// LeftJoinInt finds and returns dissimilar data from the first int collection (left).
+func LeftJoinInt(lx, rx []int) []int {
+	result := make([]int, 0, len(lx))
+	rhash := hashSliceInt(rx)
+
+	for _, v := range lx {
+		_, ok := rhash[v]
+		if !ok {
+			result = append(result, v)
+		}
+	}
+	return result
+}
+
+// LeftJoinInt finds and returns dissimilar data from the second int collection (right).
+func RightJoinInt(lx, rx []int) []int { return LeftJoinInt(rx, lx) }
+
+func hashSliceInt(arr []int) map[int]struct{} {
+	hash := make(map[int]struct{}, len(arr))
+	for _, i := range arr {
+		hash[i] = struct{}{}
+	}
+	return hash
+}
+
+type JoinInt32Fnc func(lx, rx []int32) []int32
+
+// JoinInt32 combines two int32 collections using the given join method.
+func JoinInt32(larr, rarr []int32, fnc JoinInt32Fnc) []int32 {
+	return fnc(larr, rarr)
+}
+
+// InnerJoinInt32 finds and returns matching data from two int32 collections.
+func InnerJoinInt32(lx, rx []int32) []int32 {
+	result := make([]int32, 0, len(lx)+len(rx))
+	rhash := hashSliceInt32(rx)
+	lhash := make(map[int32]struct{}, len(lx))
+
+	for _, v := range lx {
+		_, ok := rhash[v]
+		_, alreadyExists := lhash[v]
+		if ok && !alreadyExists {
+			lhash[v] = struct{}{}
+			result = append(result, v)
+		}
+	}
+	return result
+}
+
+// OuterJoinInt32 finds and returns dissimilar data from two int32 collections.
+func OuterJoinInt32(lx, rx []int32) []int32 {
+	ljoin := LeftJoinInt32(lx, rx)
+	rjoin := RightJoinInt32(lx, rx)
+
+	result := make([]int32, len(ljoin)+len(rjoin))
+	for i, v := range ljoin {
+		result[i] = v
+	}
+	for i, v := range rjoin {
+		result[len(ljoin)+i] = v
+	}
+	return result
+}
+
+// LeftJoinInt32 finds and returns dissimilar data from the first int32 collection (left).
+func LeftJoinInt32(lx, rx []int32) []int32 {
+	result := make([]int32, 0, len(lx))
+	rhash := hashSliceInt32(rx)
+
+	for _, v := range lx {
+		_, ok := rhash[v]
+		if !ok {
+			result = append(result, v)
+		}
+	}
+	return result
+}
+
+// LeftJoinInt32 finds and returns dissimilar data from the second int32 collection (right).
+func RightJoinInt32(lx, rx []int32) []int32 { return LeftJoinInt32(rx, lx) }
+
+func hashSliceInt32(arr []int32) map[int32]struct{} {
+	hash := make(map[int32]struct{}, len(arr))
+	for _, i := range arr {
+		hash[i] = struct{}{}
+	}
+	return hash
+}
+
+type JoinInt64Fnc func(lx, rx []int64) []int64
+
+// JoinInt64 combines two int64 collections using the given join method.
+func JoinInt64(larr, rarr []int64, fnc JoinInt64Fnc) []int64 {
+	return fnc(larr, rarr)
+}
+
+// InnerJoinInt64 finds and returns matching data from two int64 collections.
+func InnerJoinInt64(lx, rx []int64) []int64 {
+	result := make([]int64, 0, len(lx)+len(rx))
+	rhash := hashSliceInt64(rx)
+	lhash := make(map[int64]struct{}, len(lx))
+
+	for _, v := range lx {
+		_, ok := rhash[v]
+		_, alreadyExists := lhash[v]
+		if ok && !alreadyExists {
+			lhash[v] = struct{}{}
+			result = append(result, v)
+		}
+	}
+	return result
+}
+
+// OuterJoinInt64 finds and returns dissimilar data from two int64 collections.
+func OuterJoinInt64(lx, rx []int64) []int64 {
+	ljoin := LeftJoinInt64(lx, rx)
+	rjoin := RightJoinInt64(lx, rx)
+
+	result := make([]int64, len(ljoin)+len(rjoin))
+	for i, v := range ljoin {
+		result[i] = v
+	}
+	for i, v := range rjoin {
+		result[len(ljoin)+i] = v
+	}
+	return result
+}
+
+// LeftJoinInt64 finds and returns dissimilar data from the first int64 collection (left).
+func LeftJoinInt64(lx, rx []int64) []int64 {
+	result := make([]int64, 0, len(lx))
+	rhash := hashSliceInt64(rx)
+
+	for _, v := range lx {
+		_, ok := rhash[v]
+		if !ok {
+			result = append(result, v)
+		}
+	}
+	return result
+}
+
+// LeftJoinInt64 finds and returns dissimilar data from the second int64 collection (right).
+func RightJoinInt64(lx, rx []int64) []int64 { return LeftJoinInt64(rx, lx) }
+
+func hashSliceInt64(arr []int64) map[int64]struct{} {
+	hash := make(map[int64]struct{}, len(arr))
+	for _, i := range arr {
+		hash[i] = struct{}{}
+	}
+	return hash
+}
+
+type JoinStringFnc func(lx, rx []string) []string
+
+// JoinString combines two string collections using the given join method.
+func JoinString(larr, rarr []string, fnc JoinStringFnc) []string {
+	return fnc(larr, rarr)
+}
+
+// InnerJoinString finds and returns matching data from two string collections.
+func InnerJoinString(lx, rx []string) []string {
+	result := make([]string, 0, len(lx)+len(rx))
+	rhash := hashSliceString(rx)
+	lhash := make(map[string]struct{}, len(lx))
+
+	for _, v := range lx {
+		_, ok := rhash[v]
+		_, alreadyExists := lhash[v]
+		if ok && !alreadyExists {
+			lhash[v] = struct{}{}
+			result = append(result, v)
+		}
+	}
+	return result
+}
+
+// OuterJoinString finds and returns dissimilar data from two string collections.
+func OuterJoinString(lx, rx []string) []string {
+	ljoin := LeftJoinString(lx, rx)
+	rjoin := RightJoinString(lx, rx)
+
+	result := make([]string, len(ljoin)+len(rjoin))
+	for i, v := range ljoin {
+		result[i] = v
+	}
+	for i, v := range rjoin {
+		result[len(ljoin)+i] = v
+	}
+	return result
+}
+
+// LeftJoinString finds and returns dissimilar data from the first string collection (left).
+func LeftJoinString(lx, rx []string) []string {
+	result := make([]string, 0, len(lx))
+	rhash := hashSliceString(rx)
+
+	for _, v := range lx {
+		_, ok := rhash[v]
+		if !ok {
+			result = append(result, v)
+		}
+	}
+	return result
+}
+
+// LeftJoinString finds and returns dissimilar data from the second string collection (right).
+func RightJoinString(lx, rx []string) []string { return LeftJoinString(rx, lx) }
+
+func hashSliceString(arr []string) map[string]struct{} {
+	hash := make(map[string]struct{}, len(arr))
+	for _, i := range arr {
+		hash[i] = struct{}{}
+	}
+	return hash
+}
+
+type JoinFloat32Fnc func(lx, rx []float32) []float32
+
+// JoinFloat32 combines two float32 collections using the given join method.
+func JoinFloat32(larr, rarr []float32, fnc JoinFloat32Fnc) []float32 {
+	return fnc(larr, rarr)
+}
+
+// InnerJoinFloat32 finds and returns matching data from two float32 collections.
+func InnerJoinFloat32(lx, rx []float32) []float32 {
+	result := make([]float32, 0, len(lx)+len(rx))
+	rhash := hashSliceFloat32(rx)
+	lhash := make(map[float32]struct{}, len(lx))
+
+	for _, v := range lx {
+		_, ok := rhash[v]
+		_, alreadyExists := lhash[v]
+		if ok && !alreadyExists {
+			lhash[v] = struct{}{}
+			result = append(result, v)
+		}
+	}
+	return result
+}
+
+// OuterJoinFloat32 finds and returns dissimilar data from two float32 collections.
+func OuterJoinFloat32(lx, rx []float32) []float32 {
+	ljoin := LeftJoinFloat32(lx, rx)
+	rjoin := RightJoinFloat32(lx, rx)
+
+	result := make([]float32, len(ljoin)+len(rjoin))
+	for i, v := range ljoin {
+		result[i] = v
+	}
+	for i, v := range rjoin {
+		result[len(ljoin)+i] = v
+	}
+	return result
+}
+
+// LeftJoinFloat32 finds and returns dissimilar data from the first float32 collection (left).
+func LeftJoinFloat32(lx, rx []float32) []float32 {
+	result := make([]float32, 0, len(lx))
+	rhash := hashSliceFloat32(rx)
+
+	for _, v := range lx {
+		_, ok := rhash[v]
+		if !ok {
+			result = append(result, v)
+		}
+	}
+	return result
+}
+
+// LeftJoinFloat32 finds and returns dissimilar data from the second float32 collection (right).
+func RightJoinFloat32(lx, rx []float32) []float32 { return LeftJoinFloat32(rx, lx) }
+
+func hashSliceFloat32(arr []float32) map[float32]struct{} {
+	hash := make(map[float32]struct{}, len(arr))
+	for _, i := range arr {
+		hash[i] = struct{}{}
+	}
+	return hash
+}
+
+type JoinFloat64Fnc func(lx, rx []float64) []float64
+
+// JoinFloat64 combines two float64 collections using the given join method.
+func JoinFloat64(larr, rarr []float64, fnc JoinFloat64Fnc) []float64 {
+	return fnc(larr, rarr)
+}
+
+// InnerJoinFloat64 finds and returns matching data from two float64 collections.
+func InnerJoinFloat64(lx, rx []float64) []float64 {
+	result := make([]float64, 0, len(lx)+len(rx))
+	rhash := hashSliceFloat64(rx)
+	lhash := make(map[float64]struct{}, len(lx))
+
+	for _, v := range lx {
+		_, ok := rhash[v]
+		_, alreadyExists := lhash[v]
+		if ok && !alreadyExists {
+			lhash[v] = struct{}{}
+			result = append(result, v)
+		}
+	}
+	return result
+}
+
+// OuterJoinFloat64 finds and returns dissimilar data from two float64 collections.
+func OuterJoinFloat64(lx, rx []float64) []float64 {
+	ljoin := LeftJoinFloat64(lx, rx)
+	rjoin := RightJoinFloat64(lx, rx)
+
+	result := make([]float64, len(ljoin)+len(rjoin))
+	for i, v := range ljoin {
+		result[i] = v
+	}
+	for i, v := range rjoin {
+		result[len(ljoin)+i] = v
+	}
+	return result
+}
+
+// LeftJoinFloat64 finds and returns dissimilar data from the first float64 collection (left).
+func LeftJoinFloat64(lx, rx []float64) []float64 {
+	result := make([]float64, 0, len(lx))
+	rhash := hashSliceFloat64(rx)
+
+	for _, v := range lx {
+		_, ok := rhash[v]
+		if !ok {
+			result = append(result, v)
+		}
+	}
+	return result
+}
+
+// LeftJoinFloat64 finds and returns dissimilar data from the second float64 collection (right).
+func RightJoinFloat64(lx, rx []float64) []float64 { return LeftJoinFloat64(rx, lx) }
+
+func hashSliceFloat64(arr []float64) map[float64]struct{} {
+	hash := make(map[float64]struct{}, len(arr))
+	for _, i := range arr {
+		hash[i] = struct{}{}
+	}
+	return hash
+}

--- a/join_test.go
+++ b/join_test.go
@@ -1,0 +1,95 @@
+package funk
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJoin_InnerJoin(t *testing.T) {
+	testCases := []struct {
+		LeftArr  interface{}
+		RightArr interface{}
+		Expect   interface{}
+	}{
+		{[]string{"foo", "bar"}, []string{"bar", "baz"}, []string{"bar"}},
+		{[]string{"foo", "bar", "bar"}, []string{"bar", "baz"}, []string{"bar"}},
+		{[]string{"foo", "bar"}, []string{"bar", "bar", "baz"}, []string{"bar"}},
+		{[]string{"foo", "bar", "bar"}, []string{"bar", "bar", "baz"}, []string{"bar"}},
+		{[]int{0, 1, 2, 3, 4}, []int{3, 4, 5, 6, 7}, []int{3, 4}},
+		{[]*Foo{f, b}, []*Foo{b, c}, []*Foo{b}},
+	}
+
+	for idx, tt := range testCases {
+		t.Run(fmt.Sprintf("test case #%d", idx+1), func(t *testing.T) {
+			is := assert.New(t)
+
+			actual := Join(tt.LeftArr, tt.RightArr, InnerJoin)
+			is.Equal(tt.Expect, actual)
+		})
+	}
+}
+
+func TestJoin_OuterJoin(t *testing.T) {
+	testCases := []struct {
+		LeftArr  interface{}
+		RightArr interface{}
+		Expect   interface{}
+	}{
+		{[]string{"foo", "bar"}, []string{"bar", "baz"}, []string{"foo", "baz"}},
+		{[]int{0, 1, 2, 3, 4}, []int{3, 4, 5, 6, 7}, []int{0, 1, 2, 5, 6, 7}},
+		{[]*Foo{f, b}, []*Foo{b, c}, []*Foo{f, c}},
+	}
+
+	for idx, tt := range testCases {
+		t.Run(fmt.Sprintf("test case #%d", idx+1), func(t *testing.T) {
+			is := assert.New(t)
+
+			actual := Join(tt.LeftArr, tt.RightArr, OuterJoin)
+			is.Equal(tt.Expect, actual)
+		})
+	}
+}
+
+func TestJoin_LeftJoin(t *testing.T) {
+	testCases := []struct {
+		LeftArr  interface{}
+		RightArr interface{}
+		Expect   interface{}
+	}{
+		{[]string{"foo", "bar"}, []string{"bar", "baz"}, []string{"foo"}},
+		{[]int{0, 1, 2, 3, 4}, []int{3, 4, 5, 6, 7}, []int{0, 1, 2}},
+		{[]*Foo{f, b}, []*Foo{b, c}, []*Foo{f}},
+	}
+
+	for idx, tt := range testCases {
+		t.Run(fmt.Sprintf("test case #%d", idx+1), func(t *testing.T) {
+			is := assert.New(t)
+
+			actual := Join(tt.LeftArr, tt.RightArr, LeftJoin)
+			is.Equal(tt.Expect, actual)
+		})
+	}
+}
+
+func TestJoin_RightJoin(t *testing.T) {
+	testCases := []struct {
+		LeftArr  interface{}
+		RightArr interface{}
+		Expect   interface{}
+	}{
+		{[]string{"foo", "bar"}, []string{"bar", "baz"}, []string{"baz"}},
+		{[]int{0, 1, 2, 3, 4}, []int{3, 4, 5, 6, 7}, []int{5, 6, 7}},
+		{[]*Foo{f, b}, []*Foo{b, c}, []*Foo{c}},
+	}
+
+	for idx, tt := range testCases {
+		t.Run(fmt.Sprintf("test case #%d", idx+1), func(t *testing.T) {
+			is := assert.New(t)
+
+			actual := Join(tt.LeftArr, tt.RightArr, RightJoin)
+			is.Equal(tt.Expect, actual)
+		})
+	}
+}

--- a/lazy_builder.go
+++ b/lazy_builder.go
@@ -27,6 +27,9 @@ func (b *lazyBuilder) Initial() Builder {
 func (b *lazyBuilder) Intersect(y interface{}) Builder {
 	return &lazyBuilder{func() interface{} { return Intersect(b.exec(), y) }}
 }
+func (b *lazyBuilder) Join(rarr interface{}, fnc JoinFnc) Builder {
+	return &lazyBuilder{func() interface{} { return Join(b.exec(), rarr, fnc) }}
+}
 func (b *lazyBuilder) Map(mapFunc interface{}) Builder {
 	return &lazyBuilder{func() interface{} { return Map(b.exec(), mapFunc) }}
 }


### PR DESCRIPTION
`Join` method implements methods to combine two collections:
- It accepts all generic collection (using reflect package)
- It also accepts primitive collection ([]int, []int32, []int64, []float32, []float64, []string) through dedicated join methods
- Several join types are available:
  - Inner join
  - Outer join
  - Left join (exclusive)
  - Right join (exclusive)
- It can be chained through builders

`Join` method is used as following: `Join(CollectionA, CollectionB, Type)`. For example, a left join between two string arrays is written `Join([]string{"a","b","c"}, []string{"c","d","e"}, LeftJoin)`

**NB:** `InnerJoin` is similar to `Intersect` (a bit heavier due to deduplication check). But, because the result is not always the same (see new Intersect test), I didn't rewrote it (in order to avoid regression) but I made it as deprecated. 

Let me know if you want any additions/modifications.