### PR TITLE
Subtacting with empty array should return the first

### DIFF
--- a/subtraction.go
+++ b/subtraction.go
@@ -54,8 +54,12 @@ func Subtract(x interface{}, y interface{}) interface{} {
 
 // SubtractString returns the subtraction between two collections of string
 func SubtractString(x []string, y []string) []string {
-	if len(x) == 0 || len(y) == 0 {
+	if len(x) == 0 {
 		return []string{}
+	}
+
+	if len(y) == 0 {
+		return x
 	}
 
 	slice := []string{}

--- a/subtraction_test.go
+++ b/subtraction_test.go
@@ -17,6 +17,12 @@ func TestSubtract(t *testing.T) {
 
 	r = Subtract([]string{"hello", "foo", "bar", "hello", "bar", "hi"}, []string{"foo", "bar"})
 	is.Equal([]string{"hello", "hello", "hi"}, r)
+
+	r = Subtract([]int{1, 2, 3, 4, 5}, []int{})
+	is.Equal([]int{1, 2, 3, 4, 5}, r)
+
+	r = Subtract([]string{"bar", "bar"}, []string{})
+	is.Equal([]string{"bar", "bar"}, r)
 }
 
 func TestSubtractString(t *testing.T) {
@@ -27,4 +33,10 @@ func TestSubtractString(t *testing.T) {
 
 	r = SubtractString([]string{"foo", "bar", "hello", "bar", "world", "world"}, []string{"foo", "bar"})
 	is.Equal([]string{"hello", "world", "world"}, r)
+
+	r = SubtractString([]string{"bar", "bar"}, []string{})
+	is.Equal([]string{"bar", "bar"}, r)
+
+	r = SubtractString([]string{}, []string{"bar", "bar"})
+	is.Equal([]string{}, r)
 }


### PR DESCRIPTION
SubtactingString had a bug where calling
```
SubtractString([]string{"bar", "bar"}, []string{})
```
would return empty array 