### PR TITLE
Feature: Set Struct Field Based On Path

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -386,6 +386,37 @@ Retrieves the value of the pointer or default.
     GetOrElse(str, "foobar")    // string{"hello world"}
     GetOrElse(nil, "foobar")    // string{"foobar"}
 
+funk.Set
+........
+Set value at a path of a struct
+
+.. code-block:: go
+
+    var bar Bar = Bar{
+        Name: "level-0", 
+        Bar: &Bar{
+            Name: "level-1",
+            Bars: []*Bar{
+                {Name: "level2-1"},
+                {Name: "level2-2"},
+            },
+        },
+    }
+
+    _ = Set(&bar, "level-0-new", "Name")
+    fmt.Println(bar.Name) // "level-0-new"
+
+    MustSet(&bar, "level-1-new", "Bar.Name")
+    fmt.Println(bar.Bar.Name) // "level-1-new"
+
+    Set(&bar, "level-2-new", "Bar.Bars.Name")
+    fmt.Println(bar.Bar.Bars[0].Name) // "level-2-new"
+    fmt.Println(bar.Bar.Bars[1].Name) // "level-2-new"
+
+funk.MustSet
+............
+Short hand for funk.Set if struct does not contain interface{} field type to discard errors.
+
 
 funk.Keys
 .........

--- a/assign.go
+++ b/assign.go
@@ -12,13 +12,13 @@ import (
 // Along the path, interface{} is supported and nil ptr is initialized to ptr to zero value
 // of the type until the variable to be set is obtained.
 // It returns errors when encountering along the path unknown types, uninitialized
-// interface{} or interface{} containing struct (not ptr to struct).
+// interface{} or interface{} containing struct directly (not ptr to struct).
 //
-// Slice is resolved similarly in funk.Get(), by traversing each element of the slice,
+// Slice is resolved the same way in funk.Get(), by traversing each element of the slice,
 // so that each element of the slice's corresponding field are going to be set to the same provided val.
 // If Set is called on slice with empty path "", it behaves the same as funk.Fill()
 //
-// If in is well formed, i.e. do not expect above errors to happen, funk.MustSet()
+// If in is well formed, i.e. do not expect above descripted errors to happen, funk.MustSet()
 // is a short hand wrapper to discard error return
 func Set(in interface{}, val interface{}, path string) error {
 	if in == nil {
@@ -102,7 +102,7 @@ func set(inValue reflect.Value, setValue reflect.Value, parts []string) error {
 			// we treat this as a new call to setByParts, and it will do proper check of the types
 			return setByParts(inValue.Interface(), setValue.Interface(), parts[i:])
 		default:
-			return fmt.Errorf("kind %v in path is not supported", kind)
+			return fmt.Errorf("kind %v in path %v is not supported", kind, parts[i])
 		}
 
 	}

--- a/assign.go
+++ b/assign.go
@@ -11,9 +11,11 @@ import (
 // in accepts types of ptr to struct, ptr to variable, slice and ptr to slice.
 // Along the path, interface{} is supported and nil ptr is initialized to ptr to zero value
 // of the type until the variable to be set is obtained.
-// It returns errors when along the path unknown types, uninitialized
-// interface{} or interface{} containing struct directly (not ptr to struct).
+// It returns errors when encountering along the path unknown types, uninitialized
+// interface{} or interface{} containing struct (not ptr to struct).
+//
 // Slice is resolved similarly in funk.Get(), by traversing each element of the slice,
+// so that each element of the slice's corresponding field are going to be set to the same provided val.
 // If Set is called on slice with empty path "", it behaves the same as funk.Fill()
 //
 // If in is well formed, i.e. do not expect above errors to happen, funk.MustSet()
@@ -63,6 +65,7 @@ func set(inValue reflect.Value, setValue reflect.Value, parts []string) error {
 
 		switch kind {
 		case reflect.Invalid:
+			// do not expect this case to happen
 			return errors.New("nil pointer found along the path")
 		case reflect.Struct:
 			fValue := inValue.FieldByName(parts[i])

--- a/assign.go
+++ b/assign.go
@@ -1,0 +1,81 @@
+package funk
+
+import (
+	"reflect"
+	"strings"
+)
+
+func Set(in interface{}, val interface{}, path string) error {
+	inValue := reflect.ValueOf(in)
+
+	// TODO if it is not ptr then panic?
+	if inValue.Type().Kind() == reflect.Ptr {
+		inValue = inValue.Elem()
+	}
+
+	return set(inValue, reflect.ValueOf(val), path)
+}
+
+// Set assigns struct field with val at path
+// i.e. in.path = val
+func set(inValue reflect.Value, setValue reflect.Value, path string) error {
+
+	inKind := inValue.Type().Kind()
+
+	if inKind == reflect.Slice || inKind == reflect.Array {
+		panic("TODO array")
+	}
+
+	currRest := strings.SplitN(path, ".", 2 /* num of substr */)
+	if len(currRest) == 0 {
+		// set in to be val
+		panic("TODO no path case")
+	}
+
+	if len(currRest) == 1 {
+		// set the in's field curr to be val
+		setStructField(inValue, setValue, currRest[0])
+		return nil
+	}
+
+	// len must be 2
+	curr := currRest[0]
+	rest := currRest[1]
+	// recursive
+	fValue := inValue.FieldByName(curr)
+	if !fValue.IsValid() {
+		panic("field not found")
+	}
+
+	return set(fValue, setValue, rest)
+
+}
+
+// s is struct
+func setStructField(s reflect.Value, setValue reflect.Value, name string) {
+
+	// s := ps.Elem()
+	if s.Kind() != reflect.Struct {
+		panic("s is not struct")
+	}
+
+	// exported field
+	f := s.FieldByName(name)
+	if !f.IsValid() {
+		panic("field not found")
+	}
+	// A Value can be changed only if it is
+	// addressable and was not obtained by
+	// the use of unexported struct fields.
+	if !f.CanSet() {
+		panic("field not addressable or unexported")
+	}
+
+	// change value of
+	if f.Kind() != setValue.Kind() {
+		panic("type not match")
+	}
+
+	f.Set(setValue)
+
+}

--- a/assign.go
+++ b/assign.go
@@ -53,15 +53,6 @@ func set(inValue reflect.Value, setValue reflect.Value, parts []string) error {
 			if !fValue.CanSet() {
 				panic(fmt.Sprintf("Type %s cannot be set", inValue.Type().String()))
 			}
-			if fValue.Kind() != reflect.Ptr {
-				inValue = fValue
-				continue
-			}
-			// pointer case
-			if fValue.IsNil() {
-				// set the nil pointer to be the pointer to zero value of the type
-				fValue.Set(reflect.New(fValue.Type().Elem()))
-			}
 			inValue = fValue
 		case reflect.Slice | reflect.Array:
 			// set all its elements
@@ -74,14 +65,16 @@ func set(inValue reflect.Value, setValue reflect.Value, parts []string) error {
 			}
 			return nil
 		case reflect.Ptr:
-			if inValue.IsNil() {
-				panic("nil ptr")
-			}
 			// only traverse down one level
+			if inValue.IsNil() {
+				// set the nil pointer to be the pointer to zero value of the type
+				inValue.Set(reflect.New(inValue.Type().Elem()))
+			}
 			inValue = reflect.Indirect(inValue)
-			i-- // we did not assign parts[i]
+			i-- // we did not assign parts[i], so back off
 		default:
-			panic("not supported")
+			// TODO handle interface{} case
+			panic(fmt.Sprintf("kind %v in path is not supported", kind))
 		}
 
 	}

--- a/assign.go
+++ b/assign.go
@@ -59,10 +59,8 @@ func set(inValue reflect.Value, setValue reflect.Value, parts []string) error {
 			}
 			// pointer case
 			if fValue.IsNil() {
-				tt, _ := inValue.Type().FieldByName(parts[i])
-				// allocate zero value for invlue
-				newPtr := reflect.New(tt.Type.Elem())
-				fValue.Set(newPtr)
+				// set the nil pointer to be the pointer to zero value of the type
+				fValue.Set(reflect.New(fValue.Type().Elem()))
 			}
 			inValue = fValue
 		case reflect.Slice | reflect.Array:
@@ -99,6 +97,7 @@ func set(inValue reflect.Value, setValue reflect.Value, parts []string) error {
 	}
 
 	inValue.Set(setValue)
+	//json.Unmarshal()
 
 	return nil
 }

--- a/assign.go
+++ b/assign.go
@@ -3,6 +3,7 @@ package funk
 import (
 	"errors"
 	"fmt"
+	"log"
 	"reflect"
 	"strings"
 )
@@ -44,7 +45,7 @@ func setByParts(in interface{}, val interface{}, parts []string) error {
 // i.e. in.path = val
 func set(inValue reflect.Value, setValue reflect.Value, parts []string) error {
 
-	//log.Println(parts)
+	log.Println(parts)
 	//inKind := inValue.Type().Kind()
 
 	// traverse the path to get the inValue we need to set

--- a/assign_test.go
+++ b/assign_test.go
@@ -273,7 +273,6 @@ func TestSet_SlicePassByPtr(t *testing.T) {
 }
 
 func TestSet_SlicePassDirectly(t *testing.T) {
-	// TODO merge with above
 	var testCases = []struct {
 		Original interface{} // slice or array
 		Path     string
@@ -332,46 +331,41 @@ func TestSet_SlicePassDirectly(t *testing.T) {
 
 func TestInterface(t *testing.T) {
 
-	type Baz struct {
-		Name string
-		Itf  interface{}
-	}
-
 	var testCases = []struct {
-		OriginalBaz Baz
+		OriginalFoo Foo
 		Path        string
 		SetVal      interface{}
-		ExpectedBaz Baz
+		ExpectedFoo Foo
 	}{
 		// set string field
 		{
-			Baz{Name: "", Itf: nil},
-			"Name",
+			Foo{FirstName: ""},
+			"FirstName",
 			"hi",
-			Baz{Name: "hi", Itf: nil},
+			Foo{FirstName: "hi"},
 		},
 		// set interface{} field
 		{
-			Baz{Name: "", Itf: nil},
-			"Itf",
+			Foo{FirstName: "", GeneralInterface: nil},
+			"GeneralInterface",
 			"str",
-			Baz{Name: "", Itf: "str"},
+			Foo{FirstName: "", GeneralInterface: "str"},
 		},
 		// set field of the interface{} field
-		// TODO: set uninitialized interface{} should fail
+		// Note: set uninitialized interface{} should fail
 		// Note: interface of struct (not ptr to struct) should fail
 		{
-			Baz{Name: "", Itf: &Baz{Name: "", Itf: nil}},
-			"Itf.Name",
-			"Baz2",
-			Baz{Name: "", Itf: &Baz{Name: "Baz2", Itf: nil}},
+			Foo{FirstName: "", GeneralInterface: &Foo{FirstName: ""}}, // if Foo is not ptr this will fail
+			"GeneralInterface.FirstName",
+			"foo",
+			Foo{FirstName: "", GeneralInterface: &Foo{FirstName: "foo"}},
 		},
 		// interface two level
 		{
-			Baz{Name: "", Itf: &Baz{Name: "", Itf: nil}},
-			"Itf.Itf",
+			Foo{FirstName: "", GeneralInterface: &Foo{GeneralInterface: nil}},
+			"GeneralInterface.GeneralInterface",
 			"val",
-			Baz{Name: "", Itf: &Baz{Name: "", Itf: "val"}},
+			Foo{FirstName: "", GeneralInterface: &Foo{GeneralInterface: "val"}},
 		},
 	}
 
@@ -379,41 +373,37 @@ func TestInterface(t *testing.T) {
 		t.Run(fmt.Sprintf("test case #%d", idx+1), func(t *testing.T) {
 			is := assert.New(t)
 
-			err := Set(&tc.OriginalBaz, tc.SetVal, tc.Path)
+			err := Set(&tc.OriginalFoo, tc.SetVal, tc.Path)
 			is.NoError(err)
-			is.Equal(tc.ExpectedBaz, tc.OriginalBaz)
+			is.Equal(tc.ExpectedFoo, tc.OriginalFoo)
 		})
 	}
 
 }
 
 func TestSet_ErrorCaces(t *testing.T) {
-	type Baz struct {
-		Name string
-		Itf  interface{}
-	}
 
 	var testCases = []struct {
-		OriginalBaz Baz
+		OriginalFoo Foo
 		Path        string
 		SetVal      interface{}
 	}{
 		// uninit interface
 		// Itf is not initialized so Set cannot properly allocate type
 		{
-			Baz{Name: "", Itf: nil},
-			"Itf.Name",
+			Foo{BarInterface: nil},
+			"BarInterface.Name",
 			"val",
 		},
 		{
-			Baz{Name: "", Itf: &Baz{Name: "", Itf: nil}},
-			"Itf.Itf.Name",
+			Foo{GeneralInterface: &Foo{BarInterface: nil}},
+			"GeneralInterface.BarInterface.Name",
 			"val",
 		},
 		// type mismatch
 		{
-			Baz{Name: ""},
-			"Name",
+			Foo{FirstName: ""},
+			"FirstName",
 			20,
 		},
 	}
@@ -422,15 +412,15 @@ func TestSet_ErrorCaces(t *testing.T) {
 		t.Run(fmt.Sprintf("test case #%d", idx+1), func(t *testing.T) {
 			is := assert.New(t)
 
-			err := Set(&tc.OriginalBaz, tc.SetVal, tc.Path)
+			err := Set(&tc.OriginalFoo, tc.SetVal, tc.Path)
 			is.Error(err)
 		})
 	}
 
 	t.Run("not pointer", func(t *testing.T) {
 		is := assert.New(t)
-		baz := Baz{Name: "dummy"}
-		err := Set(baz, Baz{Name: "dummy2"}, "Name")
+		baz := Bar{Name: "dummy"}
+		err := Set(baz, Bar{Name: "dummy2"}, "Name")
 		is.Error(err)
 	})
 

--- a/assign_test.go
+++ b/assign_test.go
@@ -449,3 +449,36 @@ func TestMustSet_Basic(t *testing.T) {
 		is.Equal("b", s.Name)
 	})
 }
+
+// Examples
+
+func ExampleSet() {
+
+	var bar Bar = Bar{
+		Name: "level-0",
+		Bar: &Bar{
+			Name: "level-1",
+			Bars: []*Bar{
+				{Name: "level2-1"},
+				{Name: "level2-2"},
+			},
+		},
+	}
+
+	_ = Set(&bar, "level-0-new", "Name")
+	fmt.Println(bar.Name)
+
+	// discard error use MustSet
+	MustSet(&bar, "level-1-new", "Bar.Name")
+	fmt.Println(bar.Bar.Name)
+
+	_ = Set(&bar, "level-2-new", "Bar.Bars.Name")
+	fmt.Println(bar.Bar.Bars[0].Name)
+	fmt.Println(bar.Bar.Bars[1].Name)
+
+	// Output:
+	// level-0-new
+	// level-1-new
+	// level-2-new
+	// level-2-new
+}

--- a/assign_test.go
+++ b/assign_test.go
@@ -1,28 +1,97 @@
 package funk
 
 import (
+	"database/sql"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSetEmptyPath(t *testing.T) {
-	is := assert.New(t)
-	x := 1
-	err := Set(&x, 2, "")
-	is.NoError(err)
-	is.Equal(2, x)
+	// it is supposed to change the var passed in
+	var testCases = []struct {
+		// will use path = ""
+		Original interface{}
+		SetVal   interface{}
+	}{
+		// int
+		{
+			Original: 100,
+			SetVal:   1,
+		},
+		// string
+		{
+			Original: "",
+			SetVal:   "val",
+		},
+		// struct
+		{
+			Original: Bar{Name: "bar"},
+			SetVal:   Bar{Name: "val"},
+		},
+		// slice
+		{
+			Original: []Bar{{Name: "bar"}},
+			SetVal:   []Bar{{Name: "val1"}, {Name: "val2"}},
+		},
+	}
+
+	for idx, tc := range testCases {
+		t.Run(fmt.Sprintf("test case #%d", idx+1), func(t *testing.T) {
+			is := assert.New(t)
+			// use empty path
+			// must take the addr of the variable to be set
+			err := Set(&tc.Original, tc.SetVal, "")
+			is.NoError(err)
+			is.Equal(tc.Original, tc.SetVal) // original should be set to SetVal
+		})
+	}
 }
 
-func TestSetStructOneLevel(t *testing.T) {
+func TestSetStructBasicOneLevel(t *testing.T) {
 	is := assert.New(t)
-	// copy here because we need to modify
-	fooCopy := *foo
-	err := Set(&fooCopy, 2, "ID")
+	// we set field one by one of baz with expected value
+	baz := Foo{
+		ID:        100,
+		FirstName: "firstname",
+		LastName:  "lastname",
+		Age:       23,
+		Bar:       &Bar{Name: "bar"},
+		Bars:      []*Bar{{Name: "1"}},
+		EmptyValue: sql.NullInt64{
+			Int64: 64,
+			Valid: false,
+		},
+	}
+	expected := Foo{
+		ID:        1,
+		FirstName: "firstname1",
+		LastName:  "lastname1",
+		Age:       24,
+		Bar:       &Bar{Name: "b1", Bar: &Bar{Name: "b2"}},
+		Bars:      []*Bar{{Name: "1"}, {Name: "2"}},
+		EmptyValue: sql.NullInt64{
+			Int64: 11,
+			Valid: true,
+		},
+	}
+	err := Set(&baz, 1, "ID")
 	is.NoError(err)
-	is.Equal(2, fooCopy.ID)
-
+	err = Set(&baz, expected.FirstName, "FirstName")
+	is.NoError(err)
+	err = Set(&baz, expected.LastName, "LastName")
+	is.NoError(err)
+	err = Set(&baz, expected.Age, "Age")
+	is.NoError(err)
+	err = Set(&baz, expected.Bar, "Bar")
+	is.NoError(err)
+	err = Set(&baz, expected.Bars, "Bars")
+	is.NoError(err)
+	err = Set(&baz, expected.EmptyValue, "EmptyValue")
+	is.NoError(err)
+	is.Equal(baz, expected)
 }
 
 func TestSetStructTwoLevels(t *testing.T) {
@@ -36,6 +105,31 @@ func TestSetStructTwoLevels(t *testing.T) {
 	is.Equal(int64(2), fooCopy.EmptyValue.Int64)
 
 }
+
+func TestSetStructWithCyclicStruct(t *testing.T) {
+	is := assert.New(t)
+
+	testBar := Bar{
+		Name: "testBar",
+		Bar:  nil,
+	}
+	testBar.Bar = &testBar
+
+	err := Set(&testBar, "val", "Bar.Bar.Name")
+	is.NoError(err)
+	is.Equal("val", testBar.Name)
+}
+
+// func TestPointerCycle(t *testing.T) {
+// 	is := assert.New(t)
+
+// 	x := 10
+
+// 	intPtr := &x
+// 	intPtrPtr := &intPtr
+// 	intPtrPtr = intPtrPtr
+
+// }
 
 func TestSetStructNotPtr(t *testing.T) {
 	is := assert.New(t)
@@ -57,28 +151,130 @@ func TestSetStructWithFieldNotInitialized(t *testing.T) {
 	is.Equal("name", myFoo.Bar.Name)
 }
 
-func TestSetSlice(t *testing.T) {
-	is := assert.New(t)
-	bars := []*Bar{{Name: "a"}, {Name: "b"}}
-	// Note: take address is required
-	err := Set(&bars, "c", "Name")
-	is.NoError(err)
-	is.Equal([]*Bar{{Name: "c"}, {Name: "c"}}, bars)
+func TestSetSlicePassByPtr(t *testing.T) {
+
+	var testCases = []struct {
+		Original interface{} // slice or array
+		Path     string
+		SetVal   interface{}
+		Expected interface{}
+	}{
+		// Set Slice itself
+		{
+			Original: []*Bar{},
+			Path:     "", // empty path means set the passed in ptr itself
+			SetVal:   []*Bar{{Name: "bar"}},
+			Expected: []*Bar{{Name: "bar"}},
+		},
+		// empty slice
+		{
+			Original: []*Bar{},
+			Path:     "Name",
+			SetVal:   "val",
+			Expected: []*Bar{},
+		},
+		// slice of ptr
+		{
+			Original: []*Bar{{Name: "a"}, {Name: "b"}},
+			Path:     "Name",
+			SetVal:   "val",
+			Expected: []*Bar{{Name: "val"}, {Name: "val"}},
+		},
+		// slice of struct
+		{
+			Original: []Bar{{Name: "a"}, {Name: "b"}},
+			Path:     "Name",
+			SetVal:   "val",
+			Expected: []Bar{{Name: "val"}, {Name: "val"}},
+		},
+		// slice of empty ptr
+		{
+			Original: []*Bar{nil, nil},
+			Path:     "Name",
+			SetVal:   "val",
+			Expected: []*Bar{{Name: "val"}, {Name: "val"}},
+		},
+		// mix of init ptr and nil ptr
+		{
+			Original: []*Bar{{Name: "bar"}, nil},
+			Path:     "Name",
+			SetVal:   "val",
+			Expected: []*Bar{{Name: "val"}, {Name: "val"}},
+		},
+	}
+
+	for idx, tc := range testCases {
+		t.Run(fmt.Sprintf("test case #%d", idx+1), func(t *testing.T) {
+			is := assert.New(t)
+			// take the addr and then pass it in
+			err := Set(&tc.Original, tc.SetVal, tc.Path)
+			is.NoError(err)
+			is.Equal(tc.Expected, tc.Original)
+		})
+	}
 }
 
-func TestSetSliceWithNilElements(t *testing.T) {
-	is := assert.New(t)
-	bars := []*Bar{nil, nil}
-	// Case slice
-	err := Set(bars, "c", "Name")
-	is.NoError(err)
-	is.Equal([]*Bar{{Name: "c"}, {Name: "c"}}, bars)
+func TestSetSlicePassDirectly(t *testing.T) {
+	// TODO merge with above
+	var testCases = []struct {
+		Original interface{} // slice or array
+		Path     string
+		SetVal   interface{}
+		Expected interface{}
+	}{
+		// Set Slice itself
+		// {
+		// 	Original: []*Bar{},
+		// 	Path:     "", // empty path means set the passed in ptr itself
+		// 	SetVal:   []*Bar{{Name: "bar"}},
+		// 	Expected: []*Bar{{Name: "bar"}},
+		// }, // this will fail
+		// empty slice
+		{
+			Original: []*Bar{},
+			Path:     "Name",
+			SetVal:   "val",
+			Expected: []*Bar{},
+		},
+		// slice of ptr
+		{
+			Original: []*Bar{{Name: "a"}, {Name: "b"}},
+			Path:     "Name",
+			SetVal:   "val",
+			Expected: []*Bar{{Name: "val"}, {Name: "val"}},
+		},
+		// slice of struct
+		{
+			Original: []Bar{{Name: "a"}, {Name: "b"}},
+			Path:     "Name",
+			SetVal:   "val",
+			Expected: []Bar{{Name: "val"}, {Name: "val"}},
+		},
+		// slice of empty ptr
+		{
+			Original: []*Bar{nil, nil},
+			Path:     "Name",
+			SetVal:   "val",
+			Expected: []*Bar{{Name: "val"}, {Name: "val"}},
+		},
+		// mix of init ptr and nil ptr
+		{
+			Original: []*Bar{{Name: "bar"}, nil},
+			Path:     "Name",
+			SetVal:   "val",
+			Expected: []*Bar{{Name: "val"}, {Name: "val"}},
+		},
+	}
 
-	// Case ptr to slice
-	bars2 := []*Bar{nil, nil}
-	err = Set(&bars2, "c", "Name")
-	is.NoError(err)
-	is.Equal([]*Bar{{Name: "c"}, {Name: "c"}}, bars2)
+	for idx, tc := range testCases {
+		t.Run(fmt.Sprintf("test case #%d", idx+1), func(t *testing.T) {
+			is := assert.New(t)
+			// Not take ptr, pass directly
+			err := Set(tc.Original, tc.SetVal, tc.Path)
+			is.NoError(err)
+			is.Equal(tc.Expected, tc.Original)
+		})
+	}
 }
 
 func TestInterface(t *testing.T) {
@@ -88,40 +284,88 @@ func TestInterface(t *testing.T) {
 		Itf  interface{}
 	}
 
-	baz := Baz{
-		Name: "Baz1",
-		Itf:  nil,
-	}
-
 	var testCases = []struct {
+		OriginalBaz Baz
 		Path        string
 		SetVal      interface{}
 		ExpectedBaz Baz
 	}{
 		// set string field
 		{
+			Baz{Name: "", Itf: nil},
 			"Name",
 			"hi",
 			Baz{Name: "hi", Itf: nil},
 		},
 		// set interface{} field
 		{
+			Baz{Name: "", Itf: nil},
 			"Itf",
 			"str",
-			Baz{Name: "Baz1", Itf: "str"},
+			Baz{Name: "", Itf: "str"},
 		},
+		// set field of the interface{} field
+		// TODO: set uninitialized interface{} should fail
+		// Note: interface of struct (not ptr to struct) should fail
+		{
+			Baz{Name: "", Itf: &Baz{Name: "", Itf: nil}},
+			"Itf.Name",
+			"Baz2",
+			Baz{Name: "", Itf: &Baz{Name: "Baz2", Itf: nil}},
+		},
+		// interface two level
+		{
+			Baz{Name: "", Itf: &Baz{Name: "", Itf: nil}},
+			"Itf.Itf",
+			"val",
+			Baz{Name: "", Itf: &Baz{Name: "", Itf: "val"}},
+		},
+		// uninit interface
+		// {
+		// 	Baz{Name: "", Itf: &Baz{Name: "", Itf: nil}},
+		// 	"Itf.Itf.Name",
+		// 	"val",
+		// 	Baz{Name: "", Itf: &Baz{Name: "", Itf: &Baz{Name: "val"}}},
+		// },
+
 	}
-	//interface{}(interface{}("c"))
 
 	for idx, tc := range testCases {
 		t.Run(fmt.Sprintf("test case #%d", idx+1), func(t *testing.T) {
 			is := assert.New(t)
-			testBaz := baz // make a copy
 
-			err := Set(&testBaz, tc.SetVal, tc.Path)
+			err := Set(&tc.OriginalBaz, tc.SetVal, tc.Path)
 			is.NoError(err)
-			is.Equal(tc.ExpectedBaz, testBaz)
+			is.Equal(tc.ExpectedBaz, tc.OriginalBaz)
 		})
 	}
 
+}
+
+func TestInterfaceTry(t *testing.T) {
+	// type Baz struct {
+	// 	Name string
+	// 	Itf  interface{}
+	// }
+
+	type Baz struct {
+		Name string
+		Itf  Bar
+	}
+	baz := Baz{Name: "", Itf: Bar{Name: "dummy"}}
+
+	f := reflect.ValueOf(&baz).Elem().FieldByName("Itf")
+	if !f.CanSet() {
+		t.Error("cannot set f")
+	}
+
+	ff := f.FieldByName("Name")
+	if !ff.CanAddr() {
+		t.Error("ff cannot addr")
+	}
+
+	if !ff.CanSet() {
+		t.Error(ff.String())
+		t.Error("cannot set ff")
+	}
 }

--- a/assign_test.go
+++ b/assign_test.go
@@ -1,0 +1,31 @@
+package funk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetStructOneLevel(t *testing.T) {
+	is := assert.New(t)
+
+	// copy here because we need to modify
+	assignFoo := *foo
+
+	err := Set(&assignFoo, 2, "ID")
+	is.NoError(err)
+	is.Equal(2, assignFoo.ID)
+
+}
+
+func TestSetStructTwoLevels(t *testing.T) {
+	is := assert.New(t)
+
+	// copy here because we need to modify
+	assignFoo := *foo
+
+	err := Set(&assignFoo, int64(2), "EmptyValue.Int64")
+	is.NoError(err)
+	is.Equal(int64(2), assignFoo.EmptyValue.Int64)
+
+}

--- a/assign_test.go
+++ b/assign_test.go
@@ -1,6 +1,7 @@
 package funk
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,7 +43,7 @@ func TestSetStructNotPtr(t *testing.T) {
 	// copy here because we need to modify
 	fooCopy := *foo
 
-	is.PanicsWithValue("Type funk.Foo cannot be set", func() { Set(fooCopy, int64(2), "ID") })
+	is.PanicsWithValue("Type funk.Foo not supported by Set", func() { Set(fooCopy, int64(2), "ID") })
 
 }
 
@@ -78,4 +79,49 @@ func TestSetSliceWithNilElements(t *testing.T) {
 	err = Set(&bars2, "c", "Name")
 	is.NoError(err)
 	is.Equal([]*Bar{{Name: "c"}, {Name: "c"}}, bars2)
+}
+
+func TestInterface(t *testing.T) {
+
+	type Baz struct {
+		Name string
+		Itf  interface{}
+	}
+
+	baz := Baz{
+		Name: "Baz1",
+		Itf:  nil,
+	}
+
+	var testCases = []struct {
+		Path        string
+		SetVal      interface{}
+		ExpectedBaz Baz
+	}{
+		// set string field
+		{
+			"Name",
+			"hi",
+			Baz{Name: "hi", Itf: nil},
+		},
+		// set interface{} field
+		{
+			"Itf",
+			"str",
+			Baz{Name: "Baz1", Itf: "str"},
+		},
+	}
+	//interface{}(interface{}("c"))
+
+	for idx, tc := range testCases {
+		t.Run(fmt.Sprintf("test case #%d", idx+1), func(t *testing.T) {
+			is := assert.New(t)
+			testBaz := baz // make a copy
+
+			err := Set(&testBaz, tc.SetVal, tc.Path)
+			is.NoError(err)
+			is.Equal(tc.ExpectedBaz, testBaz)
+		})
+	}
+
 }

--- a/assign_test.go
+++ b/assign_test.go
@@ -64,3 +64,18 @@ func TestSetSlice(t *testing.T) {
 	is.NoError(err)
 	is.Equal([]*Bar{{Name: "c"}, {Name: "c"}}, bars)
 }
+
+func TestSetSliceWithNilElements(t *testing.T) {
+	is := assert.New(t)
+	bars := []*Bar{nil, nil}
+	// Case slice
+	err := Set(bars, "c", "Name")
+	is.NoError(err)
+	is.Equal([]*Bar{{Name: "c"}, {Name: "c"}}, bars)
+
+	// Case ptr to slice
+	bars2 := []*Bar{nil, nil}
+	err = Set(&bars2, "c", "Name")
+	is.NoError(err)
+	is.Equal([]*Bar{{Name: "c"}, {Name: "c"}}, bars2)
+}

--- a/assign_test.go
+++ b/assign_test.go
@@ -6,15 +6,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestSetEmptyPath(t *testing.T) {
+	is := assert.New(t)
+	x := 1
+	err := Set(&x, 2, "")
+	is.NoError(err)
+	is.Equal(2, x)
+}
+
 func TestSetStructOneLevel(t *testing.T) {
 	is := assert.New(t)
-
 	// copy here because we need to modify
-	assignFoo := *foo
-
-	err := Set(&assignFoo, 2, "ID")
+	fooCopy := *foo
+	err := Set(&fooCopy, 2, "ID")
 	is.NoError(err)
-	is.Equal(2, assignFoo.ID)
+	is.Equal(2, fooCopy.ID)
 
 }
 
@@ -22,10 +28,38 @@ func TestSetStructTwoLevels(t *testing.T) {
 	is := assert.New(t)
 
 	// copy here because we need to modify
-	assignFoo := *foo
+	fooCopy := *foo
 
-	err := Set(&assignFoo, int64(2), "EmptyValue.Int64")
+	err := Set(&fooCopy, int64(2), "EmptyValue.Int64")
 	is.NoError(err)
-	is.Equal(int64(2), assignFoo.EmptyValue.Int64)
+	is.Equal(int64(2), fooCopy.EmptyValue.Int64)
 
+}
+
+func TestSetStructNotPtr(t *testing.T) {
+	is := assert.New(t)
+
+	// copy here because we need to modify
+	fooCopy := *foo
+
+	is.PanicsWithValue("Type funk.Foo cannot be set", func() { Set(fooCopy, int64(2), "ID") })
+
+}
+
+func TestSetStructWithFieldNotInitialized(t *testing.T) {
+	is := assert.New(t)
+	myFoo := &Foo{
+		Bar: nil, // we will try to set bar's field
+	}
+	err := Set(myFoo, int64(2), "Bar.Name")
+	is.EqualError(err, "nil pointer found along the path")
+}
+
+func TestSetSlice(t *testing.T) {
+	is := assert.New(t)
+	bars := []*Bar{{Name: "a"}, {Name: "b"}}
+	// Note: take address is required
+	err := Set(bars, "c", "Name")
+	is.NoError(err)
+	is.Equal([]*Bar{{Name: "c"}, {Name: "c"}}, bars)
 }

--- a/assign_test.go
+++ b/assign_test.go
@@ -51,15 +51,16 @@ func TestSetStructWithFieldNotInitialized(t *testing.T) {
 	myFoo := &Foo{
 		Bar: nil, // we will try to set bar's field
 	}
-	err := Set(myFoo, int64(2), "Bar.Name")
-	is.EqualError(err, "nil pointer found along the path")
+	err := Set(myFoo, "name", "Bar.Name")
+	is.NoError(err)
+	is.Equal("name", myFoo.Bar.Name)
 }
 
 func TestSetSlice(t *testing.T) {
 	is := assert.New(t)
 	bars := []*Bar{{Name: "a"}, {Name: "b"}}
 	// Note: take address is required
-	err := Set(bars, "c", "Name")
+	err := Set(&bars, "c", "Name")
 	is.NoError(err)
 	is.Equal([]*Bar{{Name: "c"}, {Name: "c"}}, bars)
 }

--- a/funk_test.go
+++ b/funk_test.go
@@ -27,8 +27,9 @@ type Foo struct {
 	Bars       []*Bar
 	EmptyValue sql.NullInt64
 
-	BarInterface interface{}
-	BarPointer   interface{}
+	BarInterface     interface{}
+	BarPointer       interface{}
+	GeneralInterface interface{}
 }
 
 func (f Foo) TableName() string {

--- a/map_test.go
+++ b/map_test.go
@@ -19,7 +19,7 @@ func TestKeys(t *testing.T) {
 
 	sort.Strings(fields)
 
-	is.Equal(fields, []string{"Age", "Bar", "BarInterface", "BarPointer", "Bars", "EmptyValue", "FirstName", "ID", "LastName"})
+	is.Equal(fields, []string{"Age", "Bar", "BarInterface", "BarPointer", "Bars", "EmptyValue", "FirstName", "GeneralInterface", "ID", "LastName"})
 }
 
 func TestValues(t *testing.T) {
@@ -32,5 +32,5 @@ func TestValues(t *testing.T) {
 
 	values := Values(foo).([]interface{})
 
-	is.Len(values, 9)
+	is.Len(values, 10)
 }


### PR DESCRIPTION
funk.Set(in,val,path) Traverse "in" with path, and set the end path variable to val.

- Implemented Set() as the counter part of funk.Get().
- Resolves array in the same way as Get().
- Handles interface{} along the path.
- Added many tests.
- Changed Foo with one more field GeneralInterface to hold arbitrary value for testing.

Will change README if pull request is approved.