### PR TITLE
fix nil check in GetOrElse

### DIFF
--- a/retrieve.go
+++ b/retrieve.go
@@ -81,7 +81,7 @@ func get(value reflect.Value, path string) reflect.Value {
 // Get retrieves the value of the pointer or default.
 func GetOrElse(v interface{}, def interface{}) interface{} {
 	val := reflect.ValueOf(v)
-	if v == nil {
+	if v == nil || (val.Kind() == reflect.Ptr && val.IsNil()) {
 		return def
 	} else if val.Kind() != reflect.Ptr {
 		return v

--- a/retrieve_test.go
+++ b/retrieve_test.go
@@ -61,4 +61,12 @@ func TestGetOrElse(t *testing.T) {
 	is.Equal("hello world", GetOrElse(&str, "foobar"))
 	is.Equal("hello world", GetOrElse(str, "foobar"))
 	is.Equal("foobar", GetOrElse(nil, "foobar"))
+
+	t.Run("nil with type", func(t *testing.T) {
+		// simple nil comparison is not sufficient for nil with type.
+		is.False(interface{}((*string)(nil)) == nil)
+		// test GetOrElse coveers this case
+		is.Equal("foobar", GetOrElse((*string)(nil), "foobar"))
+	})
+
 }


### PR DESCRIPTION
fix nil check in GetOrElse.

Added handling of this case:
`is.False(interface{}((*string)(nil)) == nil)`