### PR TITLE
Fix readme prune

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -422,6 +422,7 @@ funk.Prune
 Copy a struct with only selected fields. Slice is handled by pruning all elements.
 
 .. code-block:: go
+
     bar := &Bar{
         Name: "Test",
     }


### PR DESCRIPTION
Documentation of funk.Prune does not show up. This is the fix.