### PR TITLE
Add `FlatMap` and `Flatten` transformation operations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -305,6 +305,29 @@ Manipulates an iteratee (map, slice) and transforms it to another type:
         return fmt.Sprintf("%d", k), v
     }) // map[string]string{"1": "Florent", "2": "Gilles"}
 
+funk.FlatMap
+........
+
+Manipulates an iteratee (map, slice) and transforms it to to a flattened collection of another type:
+
+* map -> slice
+* slice -> slice
+
+.. code-block:: go
+
+    r := funk.FlatMap([][]int{{1, 2}, {3, 4}}, func(x []int) []int {
+        return append(x, 0)
+    }) // []int{1, 2, 0, 3, 4, 0}
+
+    mapping := map[string][]int{
+        "Florent": {1, 2},
+        "Gilles": {3, 4},
+    }
+
+    r = funk.FlatMap(mapping, func(k string, v []int) []int {
+        return v
+    }) // []int{1, 2, 3, 4}
+
 funk.Get
 ........
 

--- a/builder.go
+++ b/builder.go
@@ -11,11 +11,13 @@ type Builder interface {
 	Compact() Builder
 	Drop(n int) Builder
 	Filter(predicate interface{}) Builder
+	Flatten() Builder
 	FlattenDeep() Builder
 	Initial() Builder
 	Intersect(y interface{}) Builder
 	Join(rarr interface{}, fnc JoinFnc) Builder
 	Map(mapFunc interface{}) Builder
+	FlatMap(mapFunc interface{}) Builder
 	Reverse() Builder
 	Shuffle() Builder
 	Tail() Builder

--- a/chain_builder.go
+++ b/chain_builder.go
@@ -21,6 +21,9 @@ func (b *chainBuilder) Drop(n int) Builder {
 func (b *chainBuilder) Filter(predicate interface{}) Builder {
 	return &chainBuilder{Filter(b.collection, predicate)}
 }
+func (b *chainBuilder) Flatten() Builder {
+	return &chainBuilder{Flatten(b.collection)}
+}
 func (b *chainBuilder) FlattenDeep() Builder {
 	return &chainBuilder{FlattenDeep(b.collection)}
 }
@@ -35,6 +38,9 @@ func (b *chainBuilder) Join(rarr interface{}, fnc JoinFnc) Builder {
 }
 func (b *chainBuilder) Map(mapFunc interface{}) Builder {
 	return &chainBuilder{Map(b.collection, mapFunc)}
+}
+func (b *chainBuilder) FlatMap(mapFunc interface{}) Builder {
+	return &chainBuilder{FlatMap(b.collection, mapFunc)}
 }
 func (b *chainBuilder) Reverse() Builder {
 	return &chainBuilder{Reverse(b.collection)}

--- a/chain_builder_test.go
+++ b/chain_builder_test.go
@@ -144,6 +144,30 @@ func TestChainFilter_SideEffect(t *testing.T) {
 	is.NotEqual([]*foo{&foo{"foo"}, &foo{"bar"}}, in)
 }
 
+func TestChainFlatten(t *testing.T) {
+	testCases := []struct {
+		In interface{}
+	}{
+		{
+			In: [][]int{{1, 2}, {3, 4}},
+		},
+		{
+			In: [][][]int{{{1, 2}, {3, 4}}, {{5, 6}}},
+		},
+	}
+
+	for idx, tc := range testCases {
+		t.Run(fmt.Sprintf("test case #%d", idx+1), func(t *testing.T) {
+			is := assert.New(t)
+
+			expected := Flatten(tc.In)
+			actual := Chain(tc.In).Flatten().Value()
+
+			is.Equal(expected, actual)
+		})
+	}
+}
+
 func TestChainFlattenDeep(t *testing.T) {
 	testCases := []struct {
 		In interface{}
@@ -257,6 +281,33 @@ func TestChainMap(t *testing.T) {
 			} else {
 				is.ElementsMatch(expected, actual)
 			}
+		})
+	}
+}
+
+func TestChainFlatMap(t *testing.T) {
+	testCases := []struct {
+		In         interface{}
+		FlatMapFnc interface{}
+	}{
+		{
+			In:         [][]int{{1}, {2}, {3}, {4}},
+			FlatMapFnc: func(x []int) []int { return x },
+		},
+		{
+			In:         map[string][]int{"Florent": {1}, "Gilles": {2}},
+			FlatMapFnc: func(k string, v []int) []int { return v },
+		},
+	}
+
+	for idx, tc := range testCases {
+		t.Run(fmt.Sprintf("test case #%d", idx+1), func(t *testing.T) {
+			is := assert.New(t)
+
+			expected := FlatMap(tc.In, tc.FlatMapFnc)
+			actual := Chain(tc.In).FlatMap(tc.FlatMapFnc).Value()
+
+			is.ElementsMatch(expected, actual)
 		})
 	}
 }

--- a/lazy_builder.go
+++ b/lazy_builder.go
@@ -18,6 +18,9 @@ func (b *lazyBuilder) Drop(n int) Builder {
 func (b *lazyBuilder) Filter(predicate interface{}) Builder {
 	return &lazyBuilder{func() interface{} { return Filter(b.exec(), predicate) }}
 }
+func (b *lazyBuilder) Flatten() Builder {
+	return &lazyBuilder{func() interface{} { return Flatten(b.exec()) }}
+}
 func (b *lazyBuilder) FlattenDeep() Builder {
 	return &lazyBuilder{func() interface{} { return FlattenDeep(b.exec()) }}
 }
@@ -32,6 +35,9 @@ func (b *lazyBuilder) Join(rarr interface{}, fnc JoinFnc) Builder {
 }
 func (b *lazyBuilder) Map(mapFunc interface{}) Builder {
 	return &lazyBuilder{func() interface{} { return Map(b.exec(), mapFunc) }}
+}
+func (b *lazyBuilder) FlatMap(mapFunc interface{}) Builder {
+	return &lazyBuilder{func() interface{} { return FlatMap(b.exec(), mapFunc) }}
 }
 func (b *lazyBuilder) Reverse() Builder {
 	return &lazyBuilder{func() interface{} { return Reverse(b.exec()) }}

--- a/lazy_builder_test.go
+++ b/lazy_builder_test.go
@@ -144,6 +144,30 @@ func TestLazyFilter_SideEffect(t *testing.T) {
 	is.NotEqual([]*foo{&foo{"foo"}, &foo{"bar"}}, in)
 }
 
+func TestLazyFlatten(t *testing.T) {
+	testCases := []struct {
+		In interface{}
+	}{
+		{
+			In: [][]int{{1, 2}, {3, 4}},
+		},
+		{
+			In: [][][]int{{{1, 2}, {3, 4}}, {{5, 6}}},
+		},
+	}
+
+	for idx, tc := range testCases {
+		t.Run(fmt.Sprintf("test case #%d", idx+1), func(t *testing.T) {
+			is := assert.New(t)
+
+			expected := Flatten(tc.In)
+			actual := LazyChain(tc.In).Flatten().Value()
+
+			is.Equal(expected, actual)
+		})
+	}
+}
+
 func TestLazyFlattenDeep(t *testing.T) {
 	testCases := []struct {
 		In interface{}
@@ -257,6 +281,33 @@ func TestLazyMap(t *testing.T) {
 			} else {
 				is.ElementsMatch(expected, actual)
 			}
+		})
+	}
+}
+
+func TestLazyFlatMap(t *testing.T) {
+	testCases := []struct {
+		In         interface{}
+		FlatMapFnc interface{}
+	}{
+		{
+			In:         [][]int{{1}, {2}, {3}, {4}},
+			FlatMapFnc: func(x []int) []int { return x },
+		},
+		{
+			In:         map[string][]int{"Florent": {1}, "Gilles": {2}},
+			FlatMapFnc: func(k string, v []int) []int { return v },
+		},
+	}
+
+	for idx, tc := range testCases {
+		t.Run(fmt.Sprintf("test case #%d", idx+1), func(t *testing.T) {
+			is := assert.New(t)
+
+			expected := Map(tc.In, tc.FlatMapFnc)
+			actual := LazyChain(tc.In).Map(tc.FlatMapFnc).Value()
+
+			is.ElementsMatch(expected, actual)
 		})
 	}
 }

--- a/transform_test.go
+++ b/transform_test.go
@@ -55,6 +55,37 @@ func TestMap(t *testing.T) {
 	is.True(resultType.Elem().Kind() == reflect.String)
 }
 
+func TestFlatMap(t *testing.T) {
+
+	is := assert.New(t)
+
+	x := reflect.Value{}.IsValid()
+	fmt.Println(x)
+
+	r := FlatMap([][]int{{1}, {2}, {3}, {4}}, func(x []int) []int {
+		return x
+	})
+
+	result, ok := r.([]int)
+
+	is.True(ok)
+	is.ElementsMatch(result, []int{1, 2, 3, 4})
+
+	mapping := map[string][]int{
+		"a": {1},
+		"b": {2},
+	}
+
+	r = FlatMap(mapping, func(k string, v []int) []int {
+		return v
+	})
+
+	result, ok = r.([]int)
+
+	is.True(ok)
+	is.ElementsMatch(result, []int{1, 2})
+}
+
 func TestToMap(t *testing.T) {
 	is := assert.New(t)
 
@@ -104,10 +135,16 @@ func TestChunk(t *testing.T) {
 	is.Len(Chunk([]int{1, 2, 3}, 0), 3)
 }
 
+func TestFlatten(t *testing.T) {
+	is := assert.New(t)
+
+	is.Equal(Flatten([][][]int{{{1, 2}}, {{3, 4}}}), [][]int{{1, 2}, {3, 4}})
+}
+
 func TestFlattenDeep(t *testing.T) {
 	is := assert.New(t)
 
-	is.Equal(FlattenDeep([][]int{{1, 2}, {3, 4}}), []int{1, 2, 3, 4})
+	is.Equal(FlattenDeep([][][]int{{{1, 2}}, {{3, 4}}}), []int{1, 2, 3, 4})
 }
 
 func TestShuffle(t *testing.T) {


### PR DESCRIPTION
I found an urge to use a `FlatMap` operation that was missing from the library.