### PR TITLE
Feature: allow retrieve with zero values

### DIFF
--- a/funk_test.go
+++ b/funk_test.go
@@ -30,6 +30,10 @@ type Foo struct {
 	BarInterface     interface{}
 	BarPointer       interface{}
 	GeneralInterface interface{}
+
+	ZeroBoolValue bool
+	ZeroIntValue  int
+	ZeroIntPtrValue *int
 }
 
 func (f Foo) TableName() string {
@@ -70,6 +74,9 @@ var foo = &Foo{
 	},
 	BarInterface: bar,
 	BarPointer:   &bar,
+	ZeroBoolValue: false,
+	ZeroIntValue: 0,
+	ZeroIntPtrValue: nil,
 }
 
 var foo2 = &Foo{

--- a/funk_test.go
+++ b/funk_test.go
@@ -31,8 +31,8 @@ type Foo struct {
 	BarPointer       interface{}
 	GeneralInterface interface{}
 
-	ZeroBoolValue bool
-	ZeroIntValue  int
+	ZeroBoolValue   bool
+	ZeroIntValue    int
 	ZeroIntPtrValue *int
 }
 
@@ -72,10 +72,10 @@ var foo = &Foo{
 		bar,
 		bar,
 	},
-	BarInterface: bar,
-	BarPointer:   &bar,
-	ZeroBoolValue: false,
-	ZeroIntValue: 0,
+	BarInterface:    bar,
+	BarPointer:      &bar,
+	ZeroBoolValue:   false,
+	ZeroIntValue:    0,
 	ZeroIntPtrValue: nil,
 }
 
@@ -115,4 +115,12 @@ var m2 = map[string]interface{}{
 	"firstname": "dark",
 	"lastname":  "vador",
 	"age":       30,
+}
+
+type FooUnexported struct {
+	unexported bool
+}
+
+var fooUnexported = &FooUnexported{
+	unexported: true,
 }

--- a/map_test.go
+++ b/map_test.go
@@ -19,7 +19,7 @@ func TestKeys(t *testing.T) {
 
 	sort.Strings(fields)
 
-	is.Equal(fields, []string{"Age", "Bar", "BarInterface", "BarPointer", "Bars", "EmptyValue", "FirstName", "GeneralInterface", "ID", "LastName"})
+	is.Equal(fields, []string{"Age", "Bar", "BarInterface", "BarPointer", "Bars", "EmptyValue", "FirstName", "GeneralInterface", "ID", "LastName", "ZeroBoolValue", "ZeroIntPtrValue", "ZeroIntValue"})
 }
 
 func TestValues(t *testing.T) {
@@ -32,5 +32,5 @@ func TestValues(t *testing.T) {
 
 	values := Values(foo).([]interface{})
 
-	is.Len(values, 10)
+	is.Len(values, 13)
 }

--- a/retrieve.go
+++ b/retrieve.go
@@ -6,27 +6,26 @@ import (
 )
 
 // Get retrieves the value at path of struct(s).
-func Get(out interface{}, path string) interface{} {
+func Get(out interface{}, path string, allowZero bool) interface{} {
 	result := get(reflect.ValueOf(out), path)
 
-	if result.Kind() != reflect.Invalid && !result.IsZero() && result.CanInterface() {
-		return result.Interface()
-	}
-
-	return nil
-}
-
-func GetAllowZero(out interface{}, path string) interface{} {
-	result := get(reflect.ValueOf(out), path)
-
+	// valid kind and we can return a result.Interface() without panic
 	if result.Kind() != reflect.Invalid && result.CanInterface() {
-		if result.Kind() == reflect.Ptr && result.IsZero() {
+		// if we don't allow zero and the result is a zero value return nil
+		if !allowZero && result.IsZero() {
 			return nil
 		}
+		// if the result kind is a pointer and its nil return nil
+		if result.Kind() == reflect.Ptr && result.IsNil() {
+			return nil
+		}
+		// return the result interface (i.e the zero value of it)
 		return result.Interface()
 	}
+
 	return nil
 }
+
 
 func get(value reflect.Value, path string) reflect.Value {
 	if value.Kind() == reflect.Slice || value.Kind() == reflect.Array {

--- a/retrieve.go
+++ b/retrieve.go
@@ -5,14 +5,52 @@ import (
 	"strings"
 )
 
-// Get retrieves the value at path of struct(s).
-func Get(out interface{}, path string, allowZero bool) interface{} {
-	result := get(reflect.ValueOf(out), path)
+// Get retrieves the value from given path, retriever can be modified with available RetrieverOptions
+func Get(out interface{}, path string, opts ...RetrieverOption) interface{} {
+	return newRetriever(opts...).Get(out, path)
+}
 
+// GetOrElse retrieves the value of the pointer or default.
+func GetOrElse(v interface{}, def interface{}) interface{} {
+	val := reflect.ValueOf(v)
+	if v == nil || (val.Kind() == reflect.Ptr && val.IsNil()) {
+		return def
+	} else if val.Kind() != reflect.Ptr {
+		return v
+	}
+	return val.Elem().Interface()
+}
+
+type RetrieverOption func(retriever *Retriever)
+
+func WithAllowZero() RetrieverOption {
+	return func(r *Retriever) {
+		r.AllowZero = true
+	}
+}
+
+type Retriever struct {
+	AllowZero bool
+}
+
+func newRetriever(opts ...RetrieverOption) *Retriever {
+	r := &Retriever{
+		AllowZero: false,
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	// return the modified retriever instance
+	return r
+}
+
+// Get retrieves the value at path of struct(s).
+func (r Retriever) Get(out interface{}, path string) interface{} {
+	result := r.get(reflect.ValueOf(out), path)
 	// valid kind and we can return a result.Interface() without panic
 	if result.Kind() != reflect.Invalid && result.CanInterface() {
 		// if we don't allow zero and the result is a zero value return nil
-		if !allowZero && result.IsZero() {
+		if !r.AllowZero && result.IsZero() {
 			return nil
 		}
 		// if the result kind is a pointer and its nil return nil
@@ -26,8 +64,7 @@ func Get(out interface{}, path string, allowZero bool) interface{} {
 	return nil
 }
 
-
-func get(value reflect.Value, path string) reflect.Value {
+func (r Retriever) get(value reflect.Value, path string) reflect.Value {
 	if value.Kind() == reflect.Slice || value.Kind() == reflect.Array {
 		var resultSlice reflect.Value
 
@@ -35,7 +72,7 @@ func get(value reflect.Value, path string) reflect.Value {
 
 		if length == 0 {
 			zeroElement := reflect.Zero(value.Type().Elem())
-			pathValue := get(zeroElement, path)
+			pathValue := r.get(zeroElement, path)
 			value = reflect.MakeSlice(reflect.SliceOf(pathValue.Type()), 0, 0)
 
 			return value
@@ -44,7 +81,7 @@ func get(value reflect.Value, path string) reflect.Value {
 		for i := 0; i < length; i++ {
 			item := value.Index(i)
 
-			resultValue := get(item, path)
+			resultValue := r.get(item, path)
 
 			if resultValue.Kind() == reflect.Invalid || resultValue.IsZero() {
 				continue
@@ -83,22 +120,11 @@ func get(value reflect.Value, path string) reflect.Value {
 		case reflect.Map:
 			value = value.MapIndex(reflect.ValueOf(part))
 		case reflect.Slice, reflect.Array:
-			value = get(value, part)
+			value = r.get(value, part)
 		default:
 			return reflect.ValueOf(nil)
 		}
 	}
 
 	return value
-}
-
-// Get retrieves the value of the pointer or default.
-func GetOrElse(v interface{}, def interface{}) interface{} {
-	val := reflect.ValueOf(v)
-	if v == nil || (val.Kind() == reflect.Ptr && val.IsNil()) {
-		return def
-	} else if val.Kind() != reflect.Ptr {
-		return v
-	}
-	return val.Elem().Interface()
 }

--- a/retrieve.go
+++ b/retrieve.go
@@ -16,6 +16,18 @@ func Get(out interface{}, path string) interface{} {
 	return nil
 }
 
+func GetAllowZero(out interface{}, path string) interface{} {
+	result := get(reflect.ValueOf(out), path)
+
+	if result.Kind() != reflect.Invalid {
+		if result.Kind() == reflect.Ptr && result.IsZero() {
+			return nil
+		}
+		return result.Interface()
+	}
+	return nil
+}
+
 func get(value reflect.Value, path string) reflect.Value {
 	if value.Kind() == reflect.Slice || value.Kind() == reflect.Array {
 		var resultSlice reflect.Value

--- a/retrieve.go
+++ b/retrieve.go
@@ -9,7 +9,7 @@ import (
 func Get(out interface{}, path string) interface{} {
 	result := get(reflect.ValueOf(out), path)
 
-	if result.Kind() != reflect.Invalid && !result.IsZero() {
+	if result.Kind() != reflect.Invalid && !result.IsZero() && result.CanInterface() {
 		return result.Interface()
 	}
 
@@ -19,7 +19,7 @@ func Get(out interface{}, path string) interface{} {
 func GetAllowZero(out interface{}, path string) interface{} {
 	result := get(reflect.ValueOf(out), path)
 
-	if result.Kind() != reflect.Invalid {
+	if result.Kind() != reflect.Invalid && result.CanInterface() {
 		if result.Kind() == reflect.Ptr && result.IsZero() {
 			return nil
 		}

--- a/retrieve.go
+++ b/retrieve.go
@@ -21,20 +21,20 @@ func GetOrElse(v interface{}, def interface{}) interface{} {
 	return val.Elem().Interface()
 }
 
-type RetrieverOption func(retriever *Retriever)
+type RetrieverOption func(retriever *retriever)
 
 func WithAllowZero() RetrieverOption {
-	return func(r *Retriever) {
+	return func(r *retriever) {
 		r.AllowZero = true
 	}
 }
 
-type Retriever struct {
+type retriever struct {
 	AllowZero bool
 }
 
-func newRetriever(opts ...RetrieverOption) *Retriever {
-	r := &Retriever{
+func newRetriever(opts ...RetrieverOption) *retriever {
+	r := &retriever{
 		AllowZero: false,
 	}
 	for _, opt := range opts {
@@ -45,7 +45,7 @@ func newRetriever(opts ...RetrieverOption) *Retriever {
 }
 
 // Get retrieves the value at path of struct(s).
-func (r Retriever) Get(out interface{}, path string) interface{} {
+func (r retriever) Get(out interface{}, path string) interface{} {
 	result := r.get(reflect.ValueOf(out), path)
 	// valid kind and we can return a result.Interface() without panic
 	if result.Kind() != reflect.Invalid && result.CanInterface() {
@@ -64,7 +64,7 @@ func (r Retriever) Get(out interface{}, path string) interface{} {
 	return nil
 }
 
-func (r Retriever) get(value reflect.Value, path string) reflect.Value {
+func (r retriever) get(value reflect.Value, path string) reflect.Value {
 	if value.Kind() == reflect.Slice || value.Kind() == reflect.Array {
 		var resultSlice reflect.Value
 

--- a/retrieve_test.go
+++ b/retrieve_test.go
@@ -9,41 +9,41 @@ import (
 func TestGetSlice(t *testing.T) {
 	is := assert.New(t)
 
-	is.Equal(Get(SliceOf(foo), "ID"), []int{1})
-	is.Equal(Get(SliceOf(foo), "Bar.Name"), []string{"Test"})
-	is.Equal(Get(SliceOf(foo), "Bar"), []*Bar{bar})
-	is.Equal(Get(([]Foo)(nil), "Bar.Name"), []string{})
-	is.Equal(Get([]Foo{}, "Bar.Name"), []string{})
-	is.Equal(Get([]*Foo{}, "Bar.Name"), []string{})
+	is.Equal(Get(SliceOf(foo), "ID", false), []int{1})
+	is.Equal(Get(SliceOf(foo), "Bar.Name", false), []string{"Test"})
+	is.Equal(Get(SliceOf(foo), "Bar", false), []*Bar{bar})
+	is.Equal(Get(([]Foo)(nil), "Bar.Name", false), []string{})
+	is.Equal(Get([]Foo{}, "Bar.Name", false), []string{})
+	is.Equal(Get([]*Foo{}, "Bar.Name", false), []string{})
 }
 
 func TestGetSliceMultiLevel(t *testing.T) {
 	is := assert.New(t)
 
-	is.Equal(Get(foo, "Bar.Bars.Bar.Name"), []string{"Level2-1", "Level2-2"})
-	is.Equal(Get(SliceOf(foo), "Bar.Bars.Bar.Name"), []string{"Level2-1", "Level2-2"})
+	is.Equal(Get(foo, "Bar.Bars.Bar.Name", false), []string{"Level2-1", "Level2-2"})
+	is.Equal(Get(SliceOf(foo), "Bar.Bars.Bar.Name", false), []string{"Level2-1", "Level2-2"})
 }
 
 func TestGetNull(t *testing.T) {
 	is := assert.New(t)
 
-	is.Equal(Get(foo, "EmptyValue.Int64"), int64(10))
-	is.Equal(Get(foo, "ZeroValue"), nil)
-	is.Equal( false, GetAllowZero(foo, "ZeroBoolValue"))
-	is.Equal( nil, GetAllowZero(fooUnexported, "unexported"))
-	is.Equal( nil, Get(fooUnexported, "unexported"))
-	is.Equal(GetAllowZero(foo, "ZeroIntValue"), 0)
-	is.Equal(GetAllowZero(foo, "ZeroIntPtrValue"), nil)
-	is.Equal(GetAllowZero(foo, "EmptyValue.Int64"), int64(10))
-	is.Equal(Get(SliceOf(foo), "EmptyValue.Int64"), []int64{10})
+	is.Equal(Get(foo, "EmptyValue.Int64", false), int64(10))
+	is.Equal(Get(foo, "ZeroValue", false), nil)
+	is.Equal( false, Get(foo, "ZeroBoolValue", true))
+	is.Equal( nil, Get(fooUnexported, "unexported", true))
+	is.Equal( nil, Get(fooUnexported, "unexported", false))
+	is.Equal(Get(foo, "ZeroIntValue", true), 0)
+	is.Equal(Get(foo, "ZeroIntPtrValue", true), nil)
+	is.Equal(Get(foo, "EmptyValue.Int64", true), int64(10))
+	is.Equal(Get(SliceOf(foo), "EmptyValue.Int64", false), []int64{10})
 }
 
 func TestGetNil(t *testing.T) {
 	is := assert.New(t)
-	is.Equal(Get(foo2, "Bar.Name"), nil)
-	is.Equal(GetAllowZero(foo2, "Bar.Name"), "")
-	is.Equal(Get([]*Foo{foo, foo2}, "Bar.Name"), []string{"Test"})
-	is.Equal(Get([]*Foo{foo, foo2}, "Bar"), []*Bar{bar})
+	is.Equal(Get(foo2, "Bar.Name", false), nil)
+	is.Equal(Get(foo2, "Bar.Name", true), "")
+	is.Equal(Get([]*Foo{foo, foo2}, "Bar.Name", false), []string{"Test"})
+	is.Equal(Get([]*Foo{foo, foo2}, "Bar", false), []*Bar{bar})
 }
 
 func TestGetMap(t *testing.T) {
@@ -54,36 +54,36 @@ func TestGetMap(t *testing.T) {
 		},
 	}
 
-	is.Equal("foobar", Get(m, "bar.name"))
-	is.Equal(nil, Get(m, "foo.name"))
-	is.Equal([]interface{}{"dark", "dark"}, Get([]map[string]interface{}{m1, m2}, "firstname"))
-	is.Equal([]interface{}{"test"}, Get([]map[string]interface{}{m1, m2}, "bar.name"))
+	is.Equal("foobar", Get(m, "bar.name", false))
+	is.Equal(nil, Get(m, "foo.name", false))
+	is.Equal([]interface{}{"dark", "dark"}, Get([]map[string]interface{}{m1, m2}, "firstname", false))
+	is.Equal([]interface{}{"test"}, Get([]map[string]interface{}{m1, m2}, "bar.name", false))
 }
 
 func TestGetThroughInterface(t *testing.T) {
 	is := assert.New(t)
 
-	is.Equal(Get(foo, "BarInterface.Bars.Bar.Name"), []string{"Level2-1", "Level2-2"})
-	is.Equal(Get(foo, "BarPointer.Bars.Bar.Name"), []string{"Level2-1", "Level2-2"})
+	is.Equal(Get(foo, "BarInterface.Bars.Bar.Name", false), []string{"Level2-1", "Level2-2"})
+	is.Equal(Get(foo, "BarPointer.Bars.Bar.Name", false), []string{"Level2-1", "Level2-2"})
 }
 
 func TestGetNotFound(t *testing.T) {
 	is := assert.New(t)
 
-	is.Equal(nil, Get(foo, "id"))
-	is.Equal(nil, Get(foo, "id.id"))
-	is.Equal(nil, Get(foo, "Bar.id"))
-	is.Equal(nil, Get(foo, "Bars.id"))
+	is.Equal(nil, Get(foo, "id", false))
+	is.Equal(nil, Get(foo, "id.id", false))
+	is.Equal(nil, Get(foo, "Bar.id", false))
+	is.Equal(nil, Get(foo, "Bars.id", false))
 }
 
 func TestGetSimple(t *testing.T) {
 	is := assert.New(t)
 
-	is.Equal(Get(foo, "ID"), 1)
+	is.Equal(Get(foo, "ID", false), 1)
 
-	is.Equal(Get(foo, "Bar.Name"), "Test")
+	is.Equal(Get(foo, "Bar.Name", false), "Test")
 
-	result := Get(foo, "Bar.Bars.Name")
+	result := Get(foo, "Bar.Bars.Name", false)
 
 	is.Equal(result, []string{"Level1-1", "Level1-2"})
 }

--- a/retrieve_test.go
+++ b/retrieve_test.go
@@ -9,41 +9,41 @@ import (
 func TestGetSlice(t *testing.T) {
 	is := assert.New(t)
 
-	is.Equal(Get(SliceOf(foo), "ID", false), []int{1})
-	is.Equal(Get(SliceOf(foo), "Bar.Name", false), []string{"Test"})
-	is.Equal(Get(SliceOf(foo), "Bar", false), []*Bar{bar})
-	is.Equal(Get(([]Foo)(nil), "Bar.Name", false), []string{})
-	is.Equal(Get([]Foo{}, "Bar.Name", false), []string{})
-	is.Equal(Get([]*Foo{}, "Bar.Name", false), []string{})
+	is.Equal(Get(SliceOf(foo), "ID"), []int{1})
+	is.Equal(Get(SliceOf(foo), "Bar.Name"), []string{"Test"})
+	is.Equal(Get(SliceOf(foo), "Bar"), []*Bar{bar})
+	is.Equal(Get(([]Foo)(nil), "Bar.Name"), []string{})
+	is.Equal(Get([]Foo{}, "Bar.Name"), []string{})
+	is.Equal(Get([]*Foo{}, "Bar.Name"), []string{})
 }
 
 func TestGetSliceMultiLevel(t *testing.T) {
 	is := assert.New(t)
 
-	is.Equal(Get(foo, "Bar.Bars.Bar.Name", false), []string{"Level2-1", "Level2-2"})
-	is.Equal(Get(SliceOf(foo), "Bar.Bars.Bar.Name", false), []string{"Level2-1", "Level2-2"})
+	is.Equal(Get(foo, "Bar.Bars.Bar.Name"), []string{"Level2-1", "Level2-2"})
+	is.Equal(Get(SliceOf(foo), "Bar.Bars.Bar.Name"), []string{"Level2-1", "Level2-2"})
 }
 
 func TestGetNull(t *testing.T) {
 	is := assert.New(t)
 
-	is.Equal(Get(foo, "EmptyValue.Int64", false), int64(10))
-	is.Equal(Get(foo, "ZeroValue", false), nil)
-	is.Equal( false, Get(foo, "ZeroBoolValue", true))
-	is.Equal( nil, Get(fooUnexported, "unexported", true))
-	is.Equal( nil, Get(fooUnexported, "unexported", false))
-	is.Equal(Get(foo, "ZeroIntValue", true), 0)
-	is.Equal(Get(foo, "ZeroIntPtrValue", true), nil)
-	is.Equal(Get(foo, "EmptyValue.Int64", true), int64(10))
-	is.Equal(Get(SliceOf(foo), "EmptyValue.Int64", false), []int64{10})
+	is.Equal(Get(foo, "EmptyValue.Int64"), int64(10))
+	is.Equal(Get(foo, "ZeroValue"), nil)
+	is.Equal( false, Get(foo, "ZeroBoolValue", WithAllowZero()))
+	is.Equal( nil, Get(fooUnexported, "unexported", WithAllowZero()))
+	is.Equal( nil, Get(fooUnexported, "unexported", WithAllowZero()))
+	is.Equal(Get(foo, "ZeroIntValue", WithAllowZero()), 0)
+	is.Equal(Get(foo, "ZeroIntPtrValue", WithAllowZero()), nil)
+	is.Equal(Get(foo, "EmptyValue.Int64", WithAllowZero()), int64(10))
+	is.Equal(Get(SliceOf(foo), "EmptyValue.Int64"), []int64{10})
 }
 
 func TestGetNil(t *testing.T) {
 	is := assert.New(t)
-	is.Equal(Get(foo2, "Bar.Name", false), nil)
-	is.Equal(Get(foo2, "Bar.Name", true), "")
-	is.Equal(Get([]*Foo{foo, foo2}, "Bar.Name", false), []string{"Test"})
-	is.Equal(Get([]*Foo{foo, foo2}, "Bar", false), []*Bar{bar})
+	is.Equal(Get(foo2, "Bar.Name"), nil)
+	is.Equal(Get(foo2, "Bar.Name", WithAllowZero()), "")
+	is.Equal(Get([]*Foo{foo, foo2}, "Bar.Name"), []string{"Test"})
+	is.Equal(Get([]*Foo{foo, foo2}, "Bar"), []*Bar{bar})
 }
 
 func TestGetMap(t *testing.T) {
@@ -54,36 +54,36 @@ func TestGetMap(t *testing.T) {
 		},
 	}
 
-	is.Equal("foobar", Get(m, "bar.name", false))
-	is.Equal(nil, Get(m, "foo.name", false))
-	is.Equal([]interface{}{"dark", "dark"}, Get([]map[string]interface{}{m1, m2}, "firstname", false))
-	is.Equal([]interface{}{"test"}, Get([]map[string]interface{}{m1, m2}, "bar.name", false))
+	is.Equal("foobar", Get(m, "bar.name"))
+	is.Equal(nil, Get(m, "foo.name"))
+	is.Equal([]interface{}{"dark", "dark"}, Get([]map[string]interface{}{m1, m2}, "firstname"))
+	is.Equal([]interface{}{"test"}, Get([]map[string]interface{}{m1, m2}, "bar.name"))
 }
 
 func TestGetThroughInterface(t *testing.T) {
 	is := assert.New(t)
 
-	is.Equal(Get(foo, "BarInterface.Bars.Bar.Name", false), []string{"Level2-1", "Level2-2"})
-	is.Equal(Get(foo, "BarPointer.Bars.Bar.Name", false), []string{"Level2-1", "Level2-2"})
+	is.Equal(Get(foo, "BarInterface.Bars.Bar.Name"), []string{"Level2-1", "Level2-2"})
+	is.Equal(Get(foo, "BarPointer.Bars.Bar.Name"), []string{"Level2-1", "Level2-2"})
 }
 
 func TestGetNotFound(t *testing.T) {
 	is := assert.New(t)
 
-	is.Equal(nil, Get(foo, "id", false))
-	is.Equal(nil, Get(foo, "id.id", false))
-	is.Equal(nil, Get(foo, "Bar.id", false))
-	is.Equal(nil, Get(foo, "Bars.id", false))
+	is.Equal(nil, Get(foo, "id"))
+	is.Equal(nil, Get(foo, "id.id"))
+	is.Equal(nil, Get(foo, "Bar.id"))
+	is.Equal(nil, Get(foo, "Bars.id"))
 }
 
 func TestGetSimple(t *testing.T) {
 	is := assert.New(t)
 
-	is.Equal(Get(foo, "ID", false), 1)
+	is.Equal(Get(foo, "ID"), 1)
 
-	is.Equal(Get(foo, "Bar.Name", false), "Test")
+	is.Equal(Get(foo, "Bar.Name"), "Test")
 
-	result := Get(foo, "Bar.Bars.Name", false)
+	result := Get(foo, "Bar.Bars.Name")
 
 	is.Equal(result, []string{"Level1-1", "Level1-2"})
 }

--- a/retrieve_test.go
+++ b/retrieve_test.go
@@ -30,6 +30,8 @@ func TestGetNull(t *testing.T) {
 	is.Equal(Get(foo, "EmptyValue.Int64"), int64(10))
 	is.Equal(Get(foo, "ZeroValue"), nil)
 	is.Equal( false, GetAllowZero(foo, "ZeroBoolValue"))
+	is.Equal( nil, GetAllowZero(fooUnexported, "unexported"))
+	is.Equal( nil, Get(fooUnexported, "unexported"))
 	is.Equal(GetAllowZero(foo, "ZeroIntValue"), 0)
 	is.Equal(GetAllowZero(foo, "ZeroIntPtrValue"), nil)
 	is.Equal(GetAllowZero(foo, "EmptyValue.Int64"), int64(10))

--- a/retrieve_test.go
+++ b/retrieve_test.go
@@ -28,13 +28,18 @@ func TestGetNull(t *testing.T) {
 	is := assert.New(t)
 
 	is.Equal(Get(foo, "EmptyValue.Int64"), int64(10))
+	is.Equal(Get(foo, "ZeroValue"), nil)
+	is.Equal( false, GetAllowZero(foo, "ZeroBoolValue"))
+	is.Equal(GetAllowZero(foo, "ZeroIntValue"), 0)
+	is.Equal(GetAllowZero(foo, "ZeroIntPtrValue"), nil)
+	is.Equal(GetAllowZero(foo, "EmptyValue.Int64"), int64(10))
 	is.Equal(Get(SliceOf(foo), "EmptyValue.Int64"), []int64{10})
 }
 
 func TestGetNil(t *testing.T) {
 	is := assert.New(t)
-
 	is.Equal(Get(foo2, "Bar.Name"), nil)
+	is.Equal(GetAllowZero(foo2, "Bar.Name"), "")
 	is.Equal(Get([]*Foo{foo, foo2}, "Bar.Name"), []string{"Test"})
 	is.Equal(Get([]*Foo{foo, foo2}, "Bar"), []*Bar{bar})
 }


### PR DESCRIPTION
Add a GetAllowZero function to retrievers 

Some struct values such as boolean false will return as nil if we use the normal Get function. 

`
foo := struct {
     X bool
    }{false}

funk.Get(foo, "X")  // -> nil, although it was set on purpose to false
funkGetAllowZero(foo, "X") // -> false
`
The same is true for empty strings, integer with the value 0 etc'.

Also in case if the type is a pointer and is Zero it will return nil, like normal get.

I fixed tests + added a few more, if PR is approved, ill add documentation/tests as required.
