### PR TITLE
Add StringerJoin()

### DIFF
--- a/join.go
+++ b/join.go
@@ -2,6 +2,7 @@ package funk
 
 import (
 	"reflect"
+	"strings"
 )
 
 type JoinFnc func(lx, rx reflect.Value) reflect.Value
@@ -83,4 +84,28 @@ func hashSlice(arr reflect.Value) map[interface{}]struct{} {
 		hash[v] = struct{}{}
 	}
 	return hash
+}
+
+// StringerJoin joins an array of elements which implement the `String() string` function.
+// Direct copy of strings.Join() with a few tweaks.
+func StringerJoin(elems []interface{ String() string }, sep string) string {
+	switch len(elems) {
+	case 0:
+		return ""
+	case 1:
+		return elems[0].String()
+	}
+	n := len(sep) * (len(elems) - 1)
+	for i := 0; i < len(elems); i++ {
+		n += len(elems[i].String())
+	}
+
+	var b strings.Builder
+	b.Grow(n)
+	b.WriteString(elems[0].String())
+	for _, s := range elems[1:] {
+		b.WriteString(sep)
+		b.WriteString(s.String())
+	}
+	return b.String()
 }

--- a/join_test.go
+++ b/join_test.go
@@ -93,3 +93,33 @@ func TestJoin_RightJoin(t *testing.T) {
 		})
 	}
 }
+
+// Struct which implements the String() method to test StringerJoin().
+type S struct {
+	Value string
+}
+
+func (s S) String() string {
+	return s.Value
+}
+
+func TestJoin_StringerJoin(t *testing.T) {
+	testCases := []struct {
+		Arr    []interface{ String() string }
+		Sep    string
+		Expect string
+	}{
+		{[]interface{ String() string }{}, ", ", ""},
+		{[]interface{ String() string }{S{"foo"}}, ", ", "foo"},
+		{[]interface{ String() string }{S{"foo"}, S{"bar"}, S{"baz"}}, ", ", "foo, bar, baz"},
+	}
+
+	for idx, tt := range testCases {
+		t.Run(fmt.Sprintf("test case #%d", idx+1), func(t *testing.T) {
+			is := assert.New(t)
+
+			actual := StringerJoin(tt.Arr, tt.Sep)
+			is.Equal(tt.Expect, actual)
+		})
+	}
+}


### PR DESCRIPTION
Join array of interfaces which implement the function `String() string`. This resolves Issue [#121](https://github.com/thoas/go-funk/issues/121).