### PR TITLE
feat: support ToMap for arrays too

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -220,7 +220,7 @@ see also, typesafe implementations: LastIndexOfInt_, LastIndexOfInt64_, LastInde
 funk.ToMap
 ..........
 
-Transforms a slice of structs to a map based on a ``pivot`` field.
+Transforms a slice or an array of structs to a map based on a ``pivot`` field.
 
 .. code-block:: go
 

--- a/transform.go
+++ b/transform.go
@@ -55,18 +55,17 @@ func Chunk(arr interface{}, size int) interface{} {
 	return resultSlice.Interface()
 }
 
-// ToMap transforms a slice of instances to a Map.
-// []*Foo => Map<int, *Foo>
+// ToMap transforms a collection of instances to a Map.
+// []T => map[type of T.<pivot>]T
 func ToMap(in interface{}, pivot string) interface{} {
-	value := reflect.ValueOf(in)
-
-	// input value must be a slice
-	if value.Kind() != reflect.Slice {
-		panic(fmt.Sprintf("%v must be a slice", in))
+	// input value must be a collection
+	if !IsCollection(in) {
+		panic(fmt.Sprintf("%v must be a slict or an array", in))
 	}
 
-	inType := value.Type()
+	value := reflect.ValueOf(in)
 
+	inType := value.Type()
 	structType := inType.Elem()
 
 	// retrieve the struct in the slice to deduce key type
@@ -74,7 +73,10 @@ func ToMap(in interface{}, pivot string) interface{} {
 		structType = structType.Elem()
 	}
 
-	field, _ := structType.FieldByName(pivot)
+	field, ok := structType.FieldByName(pivot)
+	if !ok {
+		panic(fmt.Sprintf("`%s` must be a field of the struct %s", pivot, structType.Name()))
+	}
 
 	// value of the map will be the input type
 	collectionType := reflect.MapOf(field.Type, inType.Elem())
@@ -460,7 +462,6 @@ func PruneByTag(in interface{}, paths []string, tag string) (interface{}, error)
 // which are looked up using struct field Tag "tag". If tag is nil,
 // traverse paths using struct field name
 func pruneByTag(in interface{}, paths []string, tag *string) (interface{}, error) {
-
 	inValue := reflect.ValueOf(in)
 
 	ret := reflect.New(inValue.Type()).Elem()
@@ -475,7 +476,6 @@ func pruneByTag(in interface{}, paths []string, tag *string) (interface{}, error
 }
 
 func prune(inValue reflect.Value, ret reflect.Value, parts []string, tag *string) error {
-
 	if len(parts) == 0 {
 		// we reached the location that ret needs to hold inValue
 		// Note: The value at the end of the path is not copied, maybe we need to change.
@@ -523,7 +523,7 @@ func prune(inValue reflect.Value, ret reflect.Value, parts []string, tag *string
 				}
 			}
 			if !found {
-				return fmt.Errorf("Struct tag %v is not found with key %v", *tag, part)
+				return fmt.Errorf("struct tag %v is not found with key %v", *tag, part)
 			}
 		}
 		// init Ret is zero and go down one more level

--- a/transform_test.go
+++ b/transform_test.go
@@ -56,7 +56,6 @@ func TestMap(t *testing.T) {
 }
 
 func TestFlatMap(t *testing.T) {
-
 	is := assert.New(t)
 
 	x := reflect.Value{}.IsValid()
@@ -89,7 +88,7 @@ func TestFlatMap(t *testing.T) {
 func TestToMap(t *testing.T) {
 	is := assert.New(t)
 
-	f := &Foo{
+	f1 := Foo{
 		ID:        1,
 		FirstName: "Dark",
 		LastName:  "Vador",
@@ -99,24 +98,53 @@ func TestToMap(t *testing.T) {
 		},
 	}
 
-	results := []*Foo{f}
+	f2 := Foo{
+		ID:        1,
+		FirstName: "Light",
+		LastName:  "Vador",
+		Age:       30,
+		Bar: &Bar{
+			Name: "Test",
+		},
+	}
 
-	instanceMap := ToMap(results, "ID")
+	// []*Foo -> Map<int, *Foo>
+	sliceResults := []*Foo{&f1, &f2}
 
-	is.True(reflect.TypeOf(instanceMap).Kind() == reflect.Map)
+	instanceMapByID := ToMap(sliceResults, "ID")
+	is.True(reflect.TypeOf(instanceMapByID).Kind() == reflect.Map)
 
-	mapping, ok := instanceMap.(map[int]*Foo)
-
+	mappingByID, ok := instanceMapByID.(map[int]*Foo)
 	is.True(ok)
+	is.True(len(mappingByID) == 1)
 
-	for _, result := range results {
-		item, ok := mapping[result.ID]
+	for _, result := range sliceResults {
+		item, ok := mappingByID[result.ID]
 
 		is.True(ok)
 		is.True(reflect.TypeOf(item).Kind() == reflect.Ptr)
 		is.True(reflect.TypeOf(item).Elem().Kind() == reflect.Struct)
 
 		is.Equal(item.ID, result.ID)
+	}
+
+	// Array<Foo> -> Map<string, Foo>
+	arrayResults := [4]Foo{f1, f1, f2, f2}
+
+	instanceMapByFirstName := ToMap(arrayResults, "FirstName")
+	is.True(reflect.TypeOf(instanceMapByFirstName).Kind() == reflect.Map)
+
+	mappingByFirstName, ok := instanceMapByFirstName.(map[string]Foo)
+	is.True(ok)
+	is.True(len(mappingByFirstName) == 2)
+
+	for _, result := range arrayResults {
+		item, ok := mappingByFirstName[result.FirstName]
+
+		is.True(ok)
+		is.True(reflect.TypeOf(item).Kind() == reflect.Struct)
+
+		is.Equal(item.FirstName, result.FirstName)
 	}
 }
 
@@ -207,8 +235,7 @@ func TestDrop(t *testing.T) {
 }
 
 func TestPrune(t *testing.T) {
-
-	var testCases = []struct {
+	testCases := []struct {
 		OriginalFoo *Foo
 		Paths       []string
 		ExpectedFoo *Foo
@@ -333,7 +360,7 @@ func TestPrune(t *testing.T) {
 	}
 
 	// test PruneByTag
-	var TagTestCases = []struct {
+	TagTestCases := []struct {
 		OriginalFoo *Foo
 		Paths       []string
 		ExpectedFoo *Foo
@@ -399,7 +426,7 @@ func TestPrune(t *testing.T) {
 	})
 
 	// error cases
-	var errCases = []struct {
+	errCases := []struct {
 		InputFoo *Foo
 		Paths    []string
 		TagName  *string


### PR DESCRIPTION
This PR:
- `ToMap()` is currently only for slices. This PR adds support to arrays.
- Panic when `pivot` is not a field of the struct.
   Before this PR, the panic message was ambiguous:
    ```
    panic: interface conversion: reflect.Type is nil, not *reflect.rtype [recovered]
        panic: interface conversion: reflect.Type is nil, not *reflect.rtype
    ```
    Now:
    ```
    panic: `Id` must be a field of the struct Foo [recovered]
            panic: `Id` must be a field of the struct Foo
    ```