### PR TITLE
ForEach slice modify(optional)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -597,11 +597,17 @@ funk.ForEach
 
 Range over an iteratee (map, slice).
 
+Or update element in slice(Not map, reflect#Value#MapIndex#CanSet is false).
+
 .. code-block:: go
 
     funk.ForEach([]int{1, 2, 3, 4}, func(x int) {
         fmt.Println(x)
     })
+
+    foo := []int{1,2,3}
+    funk.ForEach(foo, func(x *int){ *x = *x * 2})
+    fmt.Println(foo) // []int{2, 4, 6}
 
 funk.ForEachRight
 ............

--- a/scan.go
+++ b/scan.go
@@ -25,14 +25,20 @@ func ForEach(arr interface{}, predicate interface{}) {
 		}
 
 		arrElemType := arrValue.Type().Elem()
+		arrElemPointerType := reflect.New(arrElemType).Type()
+		usePointer := arrElemPointerType.ConvertibleTo(funcType.In(0))
 
 		// Checking whether element type is convertible to function's first argument's type.
-		if !arrElemType.ConvertibleTo(funcType.In(0)) {
+		if !arrElemType.ConvertibleTo(funcType.In(0)) && !usePointer {
 			panic("Map function's argument is not compatible with type of array.")
 		}
 
 		for i := 0; i < arrValue.Len(); i++ {
-			funcValue.Call([]reflect.Value{arrValue.Index(i)})
+			if usePointer {
+				funcValue.Call([]reflect.Value{arrValue.Index(i).Addr()})
+			} else {
+				funcValue.Call([]reflect.Value{arrValue.Index(i)})
+			}
 		}
 	}
 
@@ -79,14 +85,21 @@ func ForEachRight(arr interface{}, predicate interface{}) {
 		}
 
 		arrElemType := arrValue.Type().Elem()
+		arrElemPointerType := reflect.New(arrElemType).Type()
+		usePointer := arrElemPointerType.ConvertibleTo(funcType.In(0))
 
 		// Checking whether element type is convertible to function's first argument's type.
-		if !arrElemType.ConvertibleTo(funcType.In(0)) {
+		if !arrElemType.ConvertibleTo(funcType.In(0)) && !usePointer {
 			panic("Map function's argument is not compatible with type of array.")
 		}
 
 		for i := arrValue.Len() - 1; i >= 0; i-- {
-			funcValue.Call([]reflect.Value{arrValue.Index(i)})
+			if usePointer {
+				funcValue.Call([]reflect.Value{arrValue.Index(i).Addr()})
+			} else {
+				funcValue.Call([]reflect.Value{arrValue.Index(i)})
+			}
+
 		}
 	}
 

--- a/scan_test.go
+++ b/scan_test.go
@@ -19,6 +19,23 @@ func TestForEach(t *testing.T) {
 
 	is.Equal(results, []int{2, 4})
 
+	toModify := []int{1, 2, 3}
+	ForEach(toModify, func(x *int) { *x = *x * 2 })
+
+	is.Equal(toModify, []int{2, 4, 6})
+
+	toModify = []int{}
+	ForEach(toModify, func(x *int) {})
+
+	is.Equal(toModify, []int{})
+
+	strModify := []string{"a", "b"}
+	ForEach(strModify, func(s *string) {
+		*s = *s + *s
+	})
+
+	is.Equal(strModify, []string{"aa", "bb"})
+
 	mapping := map[int]string{
 		1: "Florent",
 		2: "Gilles",
@@ -39,6 +56,23 @@ func TestForEachRight(t *testing.T) {
 	})
 
 	is.Equal(results, []int{8, 6, 4, 2})
+
+	toModify := []int{1, 2, 3}
+	ForEach(toModify, func(x *int) { *x = *x * 2 })
+
+	is.Equal(toModify, []int{2, 4, 6})
+
+	toModify = []int{}
+	ForEach(toModify, func(x *int) {})
+
+	is.Equal(toModify, []int{})
+
+	strModify := []string{"a", "b"}
+	ForEach(strModify, func(s *string) {
+		*s = *s + *s
+	})
+
+	is.Equal(strModify, []string{"aa", "bb"})
 
 	mapping := map[int]string{
 		1: "Florent",


### PR DESCRIPTION
Maybe ForEach can modify elements is a good idea, I don't know. But some real scene need this feature.
Someone prefers
`results := []int{}`
`funk.ForEach([]int{1,2,3}, func(x int){ results = append(results, x * 2})` 
`resultsAnother := []int{}`
`funk.ForEach(results, func(x int){ resultsAnother = append(resultsAnother, x * 3})` 
but someone prefers
`data := []int{1,2,3}`
`funk.ForEach(data, func(x *int){ *x = *x * 2})`
`funk.ForEach(data, func(x *int){ *x = *x * 3})`

go's map cannot be modified by the reflect value. reflect#Value#MapIndex#CanSet is false. Use SetMapIndex is a way, but it need a `func(x *any) any` as predicate func  breaks go-funk's consensual, so I left it.