### PR TITLE
fix: Only consider pointer to structs when checking for embedded fields

### DIFF
--- a/funk_test.go
+++ b/funk_test.go
@@ -129,8 +129,14 @@ type EmbeddedStruct struct {
 	EmbeddedField *string
 }
 
-type RootStruct struct {
+type RootStructPointer struct {
 	*EmbeddedStruct
+
+	RootField *string
+}
+
+type RootStructNotPointer struct {
+	EmbeddedStruct
 
 	RootField *string
 }

--- a/retrieve.go
+++ b/retrieve.go
@@ -110,14 +110,11 @@ func isNilIndirection(v reflect.Value, name string) bool {
 	vType := v.Type()
 	for i := 0; i < vType.NumField(); i++ {
 		field := vType.Field(i)
-		if !isEmbeddedStructField(field) {
+		if !isEmbeddedStructPointerField(field) {
 			return false
 		}
 
-		fieldType := field.Type
-		if fieldType.Kind() == reflect.Ptr {
-			fieldType = field.Type.Elem()
-		}
+		fieldType := field.Type.Elem()
 
 		_, found := fieldType.FieldByName(name)
 		if found {
@@ -128,13 +125,9 @@ func isNilIndirection(v reflect.Value, name string) bool {
 	return false
 }
 
-func isEmbeddedStructField(field reflect.StructField) bool {
+func isEmbeddedStructPointerField(field reflect.StructField) bool {
 	if !field.Anonymous {
 		return false
-	}
-
-	if field.Type.Kind() == reflect.Struct {
-		return true
 	}
 
 	return field.Type.Kind() == reflect.Ptr && field.Type.Elem().Kind() == reflect.Struct

--- a/retrieve_test.go
+++ b/retrieve_test.go
@@ -102,10 +102,17 @@ func TestGetOrElse(t *testing.T) {
 	})
 }
 
-func TestEmbeddedStruct(t *testing.T) {
+func TestEmbeddedStructPointer(t *testing.T) {
 	is := assert.New(t)
 
-	root := RootStruct{}
+	root := RootStructPointer{}
 	is.Equal(Get(root, "EmbeddedField"), nil)
 	is.Equal(Get(root, "EmbeddedStruct.EmbeddedField"), nil)
+}
+
+func TestEmbeddedStructNotPointer(t *testing.T) {
+	is := assert.New(t)
+
+	root := RootStructNotPointer{}
+	is.Equal(Get(root, "EmbeddedField"), nil)
 }


### PR DESCRIPTION
Sorry for the trouble but I've noticed this in our CI tests after updating to `go-funk` version with my fix.

This is a follow up to https://github.com/thoas/go-funk/pull/159

We should only consider pointer to structs when looking at embedded structs, as non pointers can never be `nil`.
The previous code would panic on structs since I used `IsNil` which can only called on pointers to structs.

This fixes the issue and adds a test to catch the previous panic