### PR TITLE
fix: Update LastIndexOf sample code in README.rst 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -204,9 +204,9 @@ if the value cannot be found.
 
     // slice of string
     funk.LastIndexOf([]string{"foo", "bar", "bar"}, "bar") // 2
-    funk.LastIndexOf([]string{"foo", "bar"}, func(value string) bool {
+    funk.LastIndexOf([]string{"foo", "bar", "bar"}, func(value string) bool {
         return value == "bar"
-    }) // 1
+    }) // 2
     funk.LastIndexOf([]string{"foo", "bar"}, "gilles") // -1
 
 see also, typesafe implementations: LastIndexOfInt_, LastIndexOfInt64_, LastIndexOfFloat32_, LastIndexOfFloat64_, LastIndexOfString_

--- a/README.rst
+++ b/README.rst
@@ -206,7 +206,7 @@ if the value cannot be found.
     funk.LastIndexOf([]string{"foo", "bar", "bar"}, "bar") // 2
     funk.LastIndexOf([]string{"foo", "bar"}, func(value string) bool {
         return value == "bar"
-    }) // 2
+    }) // 1
     funk.LastIndexOf([]string{"foo", "bar"}, "gilles") // -1
 
 see also, typesafe implementations: LastIndexOfInt_, LastIndexOfInt64_, LastIndexOfFloat32_, LastIndexOfFloat64_, LastIndexOfString_


### PR DESCRIPTION
after testing, the result of `funk.LastIndexOf([]string{"foo", "bar"}, func(value string) bool {
    return value == "bar"
})` is 1, and I gusse that this sample code may missed a "bar"
